### PR TITLE
[feat] 유저 정보조회 / 유저탈퇴 / 유저 TIL 횟수 기록 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,54 +1,72 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.5'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.5'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
-
-	//모기코
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
-	testImplementation 'org.mockito:mockito-core:5.2.0'
-	testImplementation 'org.mockito:mockito-junit-jupiter:5.2.0'
-	testImplementation 'org.assertj:assertj-core:3.24.2'
-	testImplementation 'com.h2database:h2'
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'io.projectreactor:reactor-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'  // Spring Boot 3 이상이면 5.x 써야 안정적
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+    //모기코
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+    testImplementation 'org.mockito:mockito-core:5.2.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.2.0'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'com.h2database:h2'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main {
+        java {
+            srcDir querydslDir
+        }
+    }
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+    options.compilerArgs << "-parameters"
 }

--- a/src/main/generated/com/youtil/Model/QBaseTime.java
+++ b/src/main/generated/com/youtil/Model/QBaseTime.java
@@ -1,0 +1,39 @@
+package com.youtil.Model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTime is a Querydsl query type for BaseTime
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTime extends EntityPathBase<BaseTime> {
+
+    private static final long serialVersionUID = 1782515340L;
+
+    public static final QBaseTime baseTime = new QBaseTime("baseTime");
+
+    public final DateTimePath<java.time.OffsetDateTime> createdAt = createDateTime("createdAt", java.time.OffsetDateTime.class);
+
+    public final DateTimePath<java.time.OffsetDateTime> updatedAt = createDateTime("updatedAt", java.time.OffsetDateTime.class);
+
+    public QBaseTime(String variable) {
+        super(BaseTime.class, forVariable(variable));
+    }
+
+    public QBaseTime(Path<? extends BaseTime> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTime(PathMetadata metadata) {
+        super(BaseTime.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/youtil/Model/QComment.java
+++ b/src/main/generated/com/youtil/Model/QComment.java
@@ -1,0 +1,71 @@
+package com.youtil.Model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QComment is a Querydsl query type for Comment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QComment extends EntityPathBase<Comment> {
+
+    private static final long serialVersionUID = -1430420655L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QComment comment = new QComment("comment");
+
+    public final QBaseTime _super = new QBaseTime(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> createdAt = _super.createdAt;
+
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<com.youtil.Common.Enums.Status> status = createEnum("status", com.youtil.Common.Enums.Status.class);
+
+    public final QTil til;
+
+    public final QComment topComment;
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> updatedAt = _super.updatedAt;
+
+    public final QUser user;
+
+    public QComment(String variable) {
+        this(Comment.class, forVariable(variable), INITS);
+    }
+
+    public QComment(Path<? extends Comment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QComment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QComment(PathMetadata metadata, PathInits inits) {
+        this(Comment.class, metadata, inits);
+    }
+
+    public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.til = inits.isInitialized("til") ? new QTil(forProperty("til"), inits.get("til")) : null;
+        this.topComment = inits.isInitialized("topComment") ? new QComment(forProperty("topComment"), inits.get("topComment")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/youtil/Model/QGuestbook.java
+++ b/src/main/generated/com/youtil/Model/QGuestbook.java
@@ -1,0 +1,71 @@
+package com.youtil.Model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QGuestbook is a Querydsl query type for Guestbook
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QGuestbook extends EntityPathBase<Guestbook> {
+
+    private static final long serialVersionUID = 362536243L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QGuestbook guestbook = new QGuestbook("guestbook");
+
+    public final QBaseTime _super = new QBaseTime(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> createdAt = _super.createdAt;
+
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
+    public final QUser guest;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QUser owner;
+
+    public final EnumPath<com.youtil.Common.Enums.Status> status = createEnum("status", com.youtil.Common.Enums.Status.class);
+
+    public final QGuestbook topGuestbook;
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> updatedAt = _super.updatedAt;
+
+    public QGuestbook(String variable) {
+        this(Guestbook.class, forVariable(variable), INITS);
+    }
+
+    public QGuestbook(Path<? extends Guestbook> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QGuestbook(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QGuestbook(PathMetadata metadata, PathInits inits) {
+        this(Guestbook.class, metadata, inits);
+    }
+
+    public QGuestbook(Class<? extends Guestbook> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.guest = inits.isInitialized("guest") ? new QUser(forProperty("guest")) : null;
+        this.owner = inits.isInitialized("owner") ? new QUser(forProperty("owner")) : null;
+        this.topGuestbook = inits.isInitialized("topGuestbook") ? new QGuestbook(forProperty("topGuestbook"), inits.get("topGuestbook")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/youtil/Model/QInterview.java
+++ b/src/main/generated/com/youtil/Model/QInterview.java
@@ -1,0 +1,69 @@
+package com.youtil.Model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QInterview is a Querydsl query type for Interview
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QInterview extends EntityPathBase<Interview> {
+
+    private static final long serialVersionUID = 1753412083L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QInterview interview = new QInterview("interview");
+
+    public final QBaseTime _super = new QBaseTime(this);
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> createdAt = _super.createdAt;
+
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<com.youtil.Common.Enums.Level> level = createEnum("level", com.youtil.Common.Enums.Level.class);
+
+    public final ListPath<InterviewQuestion, QInterviewQuestion> questions = this.<InterviewQuestion, QInterviewQuestion>createList("questions", InterviewQuestion.class, QInterviewQuestion.class, PathInits.DIRECT2);
+
+    public final EnumPath<com.youtil.Common.Enums.Status> status = createEnum("status", com.youtil.Common.Enums.Status.class);
+
+    public final QTil til;
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> updatedAt = _super.updatedAt;
+
+    public QInterview(String variable) {
+        this(Interview.class, forVariable(variable), INITS);
+    }
+
+    public QInterview(Path<? extends Interview> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QInterview(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QInterview(PathMetadata metadata, PathInits inits) {
+        this(Interview.class, metadata, inits);
+    }
+
+    public QInterview(Class<? extends Interview> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.til = inits.isInitialized("til") ? new QTil(forProperty("til"), inits.get("til")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/youtil/Model/QInterviewQuestion.java
+++ b/src/main/generated/com/youtil/Model/QInterviewQuestion.java
@@ -1,0 +1,55 @@
+package com.youtil.Model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QInterviewQuestion is a Querydsl query type for InterviewQuestion
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QInterviewQuestion extends EntityPathBase<InterviewQuestion> {
+
+    private static final long serialVersionUID = -1370231047L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QInterviewQuestion interviewQuestion = new QInterviewQuestion("interviewQuestion");
+
+    public final StringPath answer = createString("answer");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QInterview interview;
+
+    public final StringPath question = createString("question");
+
+    public QInterviewQuestion(String variable) {
+        this(InterviewQuestion.class, forVariable(variable), INITS);
+    }
+
+    public QInterviewQuestion(Path<? extends InterviewQuestion> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QInterviewQuestion(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QInterviewQuestion(PathMetadata metadata, PathInits inits) {
+        this(InterviewQuestion.class, metadata, inits);
+    }
+
+    public QInterviewQuestion(Class<? extends InterviewQuestion> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.interview = inits.isInitialized("interview") ? new QInterview(forProperty("interview"), inits.get("interview")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/youtil/Model/QNews.java
+++ b/src/main/generated/com/youtil/Model/QNews.java
@@ -1,0 +1,53 @@
+package com.youtil.Model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QNews is a Querydsl query type for News
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNews extends EntityPathBase<News> {
+
+    private static final long serialVersionUID = 1337158433L;
+
+    public static final QNews news = new QNews("news");
+
+    public final QBaseTime _super = new QBaseTime(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath originUrl = createString("originUrl");
+
+    public final StringPath thumbnail = createString("thumbnail");
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> updatedAt = _super.updatedAt;
+
+    public QNews(String variable) {
+        super(News.class, forVariable(variable));
+    }
+
+    public QNews(Path<? extends News> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QNews(PathMetadata metadata) {
+        super(News.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/youtil/Model/QTil.java
+++ b/src/main/generated/com/youtil/Model/QTil.java
@@ -1,0 +1,85 @@
+package com.youtil.Model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QTil is a Querydsl query type for Til
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTil extends EntityPathBase<Til> {
+
+    private static final long serialVersionUID = -1342333303L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QTil til = new QTil("til");
+
+    public final QBaseTime _super = new QBaseTime(this);
+
+    public final StringPath category = createString("category");
+
+    public final NumberPath<Integer> commentsCount = createNumber("commentsCount", Integer.class);
+
+    public final StringPath commitRepository = createString("commitRepository");
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> createdAt = _super.createdAt;
+
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final ListPath<Interview, QInterview> interviews = this.<Interview, QInterview>createList("interviews", Interview.class, QInterview.class, PathInits.DIRECT2);
+
+    public final BooleanPath isDisplay = createBoolean("isDisplay");
+
+    public final BooleanPath isUploaded = createBoolean("isUploaded");
+
+    public final NumberPath<Integer> recommendCount = createNumber("recommendCount", Integer.class);
+
+    public final EnumPath<com.youtil.Common.Enums.Status> status = createEnum("status", com.youtil.Common.Enums.Status.class);
+
+    public final StringPath tag = createString("tag");
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> updatedAt = _super.updatedAt;
+
+    public final QUser user;
+
+    public final NumberPath<Integer> visitedCount = createNumber("visitedCount", Integer.class);
+
+    public QTil(String variable) {
+        this(Til.class, forVariable(variable), INITS);
+    }
+
+    public QTil(Path<? extends Til> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QTil(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QTil(PathMetadata metadata, PathInits inits) {
+        this(Til.class, metadata, inits);
+    }
+
+    public QTil(Class<? extends Til> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/youtil/Model/QTilRecommend.java
+++ b/src/main/generated/com/youtil/Model/QTilRecommend.java
@@ -1,0 +1,62 @@
+package com.youtil.Model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QTilRecommend is a Querydsl query type for TilRecommend
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTilRecommend extends EntityPathBase<TilRecommend> {
+
+    private static final long serialVersionUID = -1104552909L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QTilRecommend tilRecommend = new QTilRecommend("tilRecommend");
+
+    public final QBaseTime _super = new QBaseTime(this);
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QTil til;
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> updatedAt = _super.updatedAt;
+
+    public final QUser user;
+
+    public QTilRecommend(String variable) {
+        this(TilRecommend.class, forVariable(variable), INITS);
+    }
+
+    public QTilRecommend(Path<? extends TilRecommend> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QTilRecommend(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QTilRecommend(PathMetadata metadata, PathInits inits) {
+        this(TilRecommend.class, metadata, inits);
+    }
+
+    public QTilRecommend(Class<? extends TilRecommend> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.til = inits.isInitialized("til") ? new QTil(forProperty("til"), inits.get("til")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/youtil/Model/QUser.java
+++ b/src/main/generated/com/youtil/Model/QUser.java
@@ -1,0 +1,61 @@
+package com.youtil.Model;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = 1337379865L;
+
+    public static final QUser user = new QUser("user");
+
+    public final QBaseTime _super = new QBaseTime(this);
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> createdAt = _super.createdAt;
+
+    public final DateTimePath<java.time.LocalDateTime> deactivatedAt = createDateTime("deactivatedAt", java.time.LocalDateTime.class);
+
+    public final StringPath description = createString("description");
+
+    public final StringPath email = createString("email");
+
+    public final StringPath githubToken = createString("githubToken");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath profileImageUrl = createString("profileImageUrl");
+
+    public final EnumPath<com.youtil.Common.Enums.Status> status = createEnum("status", com.youtil.Common.Enums.Status.class);
+
+    //inherited
+    public final DateTimePath<java.time.OffsetDateTime> updatedAt = _super.updatedAt;
+
+    public final StringPath uploadRepository = createString("uploadRepository");
+
+    public QUser(String variable) {
+        super(User.class, forVariable(variable));
+    }
+
+    public QUser(Path<? extends User> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUser(PathMetadata metadata) {
+        super(User.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/youtil/Api/User/Controller/UserController.java
+++ b/src/main/java/com/youtil/Api/User/Controller/UserController.java
@@ -4,22 +4,61 @@ import com.youtil.Api.User.Dto.UserRequestDTO;
 import com.youtil.Api.User.Dto.UserResponseDTO;
 import com.youtil.Api.User.Service.UserService;
 import com.youtil.Common.ApiResponse;
-import lombok.NoArgsConstructor;
+import com.youtil.Util.JwtUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "user", description = "유저 관련 API")
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
-    private final UserService userService;
-    @PostMapping("/github")
-    public ApiResponse<UserResponseDTO.LoginResponseDTO> LoginUserController(@RequestBody UserRequestDTO.LoginRequestDTO loginRequestDTO){
 
-        return new ApiResponse<>("로그인에 성공했습니다!","200",userService.loginUserService(loginRequestDTO.getAuthorizationCode()));
+    private final UserService userService;
+
+    @Operation(summary = "github 로그인", description = "깃허브 소셜 로그인입니다.")
+    @PostMapping("/github")
+    public ApiResponse<UserResponseDTO.LoginResponseDTO> loginUserController(
+            @RequestBody UserRequestDTO.LoginRequestDTO loginRequestDTO) {
+
+        return new ApiResponse<>("로그인에 성공했습니다!", "200",
+                userService.loginUserService(loginRequestDTO.getAuthorizationCode()));
     }
+
+    @Operation(summary = "유저 정보 조회", description = "마이페이지의 유저 정보를 조회하는 API 입니다")
+    @GetMapping("/{userId}")
+    public ApiResponse<UserResponseDTO.GetUserInfoResponseDTO> getUserController(
+            @Parameter(name = "userId", description = "유저 아이디 입력입니다.", required = true, example = "382")
+            @PathVariable Long userId) {
+        return new ApiResponse<>("유저 조회에 성공했습니다!", "200", userService.getUserInfoService(userId));
+
+    }
+
+    @Operation(summary = "유저 탈퇴", description = "유저 탈퇴를 조회하는 API 입니다.")
+    @DeleteMapping("")
+    public ApiResponse<String> deleteUserController() {
+        userService.inactiveUserService(JwtUtil.getAuthenticatedUserId());
+        return new ApiResponse<>("유저 탈퇴에 성공했습니다!", "200");
+    }
+
+    @Operation(summary = "유저 til 기록 조회", description = "유저 til 기록을 조회하는 API 입니다.")
+    @GetMapping("/tils")
+    public ApiResponse<UserResponseDTO.GetUserTilCountResponseDTO> getUserTilCountController(
+            @Parameter(name = "year", description = "연도입니다", required = true, example = "2025")
+            @RequestParam Integer year) {
+
+        return new ApiResponse<>("유저 til 조회에 성공했습니다!", "200",
+                userService.getUserTilCountService(JwtUtil.getAuthenticatedUserId(), year));
+    }
+
 }

--- a/src/main/java/com/youtil/Api/User/Converter/UserConverter.java
+++ b/src/main/java/com/youtil/Api/User/Converter/UserConverter.java
@@ -25,4 +25,12 @@ public class UserConverter {
                 .refreshToken(refreshToken)
                 .build();
     }
+
+    public static UserResponseDTO.GetUserInfoResponseDTO toUserInfoResponseDTO(User user) {
+        return UserResponseDTO.GetUserInfoResponseDTO.builder()
+                .name(user.getNickname())
+                .profileUrl(user.getProfileImageUrl())
+                .description(user.getDescription())
+                .build();
+    }
 }

--- a/src/main/java/com/youtil/Api/User/Dto/UserRequestDTO.java
+++ b/src/main/java/com/youtil/Api/User/Dto/UserRequestDTO.java
@@ -1,10 +1,14 @@
 package com.youtil.Api.User.Dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 public class UserRequestDTO {
+
     @Getter
-    public static class LoginRequestDTO{
+    public static class LoginRequestDTO {
+
+        @Schema(description = "깃허브 인가 코드", example = "1jjdwoqjdoxjcv")
         String authorizationCode;
     }
 }

--- a/src/main/java/com/youtil/Api/User/Dto/UserResponseDTO.java
+++ b/src/main/java/com/youtil/Api/User/Dto/UserResponseDTO.java
@@ -1,14 +1,76 @@
 package com.youtil.Api.User.Dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
 public class UserResponseDTO {
+
     @Getter
     @Builder
+    @Schema(description = "로그인 응답")
     public static class LoginResponseDTO {
+
+        @Schema(description = "엑세스토큰")
         private String accessToken;
+        @Schema(description = "리프레쉬토큰")
         private String refreshToken;
     }
 
+    @Getter
+    @Builder
+    @Schema(description = "유저 정보 조회")
+    public static class GetUserInfoResponseDTO {
+
+        @Schema(description = "유저 이름", example = "jun")
+        private String name;
+        @Schema(description = "유저 프로필url", example = "jun")
+        private String profileUrl;
+        @Schema(description = "유저 자기소개", example = "안녕")
+        private String description;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "TIL 카운트 조회")
+    public static class GetUserTilCountResponseDTO {
+
+        @Schema(description = "연도", example = "2025")
+        private int year;
+        @Schema(description = "TIL 카운트 정보")
+        private TilCountYears tils;
+
+    }
+
+    @Getter
+    @Builder
+    public static class TilCountYears {
+
+        @Schema(description = "1월", example = "[0,0,0,0]")
+        private List<Integer> jan;
+        @Schema(description = "2월", example = "[0,0,0,0]")
+        private List<Integer> feb;
+        @Schema(description = "3월", example = "[0,0,0,0]")
+        private List<Integer> mar;
+        @Schema(description = "4월", example = "[0,0,0,0]")
+        private List<Integer> apr;
+        @Schema(description = "5월", example = "[0,0,0,0]")
+        private List<Integer> may;
+        @Schema(description = "6월", example = "[0,0,0,0]")
+        private List<Integer> jun;
+        @Schema(description = "7월", example = "[0,0,0,0]")
+        private List<Integer> jul;
+        @Schema(description = "8월", example = "[0,0,0,0]")
+        private List<Integer> aug;
+        @Schema(description = "9월", example = "[0,0,0,0]")
+        private List<Integer> sep;
+        @Schema(description = "10월", example = "[0,0,0,0]")
+        private List<Integer> oct;
+        @Schema(description = "11월", example = "[0,0,0,0]")
+        private List<Integer> nov;
+        @Schema(description = "12월", example = "[0,0,0,0]")
+        private List<Integer> dec;
+
+    }
 }

--- a/src/main/java/com/youtil/Common/ApiResponse.java
+++ b/src/main/java/com/youtil/Common/ApiResponse.java
@@ -14,20 +14,23 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ApiResponse<T> {
+
     private String message;
-    private boolean success;
+    private boolean success = true;
     private String code;
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-    private OffsetDateTime responseAt= OffsetDateTime.now();
-    private T data=null;
+    private OffsetDateTime responseAt = OffsetDateTime.now();
+    private T data = null;
+
     //Post 또는 GET
-    public ApiResponse(String message,String code, T data){
+    public ApiResponse(String message, String code, T data) {
         this.message = message;
         this.code = code;
         this.data = data;
     }
+
     //UPDATE 또는 DELETE
-    public ApiResponse(String message,String code){
+    public ApiResponse(String message, String code) {
         this.message = message;
         this.code = code;
     }

--- a/src/main/java/com/youtil/Common/Enums/ErrorMessageCode.java
+++ b/src/main/java/com/youtil/Common/Enums/ErrorMessageCode.java
@@ -1,0 +1,12 @@
+package com.youtil.Common.Enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorMessageCode {
+    USER_NOT_FOUND("유저를 찾을 수 없거나 탈퇴한 계정입니다."),
+    USER_ALREADY_INACTIVE("유저가 탈퇴되어있는 상태입니다.");
+    private final String message;
+}

--- a/src/main/java/com/youtil/Common/Enums/MessageCode.java
+++ b/src/main/java/com/youtil/Common/Enums/MessageCode.java
@@ -1,0 +1,25 @@
+package com.youtil.Common.Enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MessageCode {
+    // 유저 관련 성공 메시지
+    PROFILE_UPDATED("프로필 변경에 성공했습니다."),
+    PASSWORD_UPDATED("비밀번호 변경에 성공했습니다."),
+    USER_DEACTIVE("회원 탈퇴가 완료되었습니다."),
+    
+    // 게시물 관련 메시지
+    POST_CREATED("게시물이 성공적으로 생성되었습니다."),
+    POST_UPDATED("게시물 수정에 성공했습니다."),
+    POST_DELETED("삭제에 성공했습니다."),
+
+    // 댓글 관련 메시지
+    COMMENT_CREATED("댓글이 성공적으로 등록되었습니다."),
+    COMMENT_UPDATED("댓글 수정에 성공했습니다."),
+    COMMENT_DELETED("댓글 삭제에 성공했습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/youtil/Config/QueryDslConfig.java
+++ b/src/main/java/com/youtil/Config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.youtil.Config;
+
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/youtil/Config/SwaggerConfig.java
+++ b/src/main/java/com/youtil/Config/SwaggerConfig.java
@@ -17,7 +17,7 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         String jwt = "JWT";
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList("jwt");
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
         Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
                 .name(jwt)
                 .type(SecurityScheme.Type.HTTP)

--- a/src/main/java/com/youtil/Exception/UserException/UserException.java
+++ b/src/main/java/com/youtil/Exception/UserException/UserException.java
@@ -1,0 +1,14 @@
+package com.youtil.Exception.UserException;
+
+import com.youtil.Common.Enums.ErrorMessageCode;
+
+public class UserException {
+
+
+    public static class UserNotFoundException extends RuntimeException {
+
+        public UserNotFoundException() {
+            super(ErrorMessageCode.USER_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/youtil/Exception/UserException/UserExceptionController.java
+++ b/src/main/java/com/youtil/Exception/UserException/UserExceptionController.java
@@ -1,0 +1,20 @@
+package com.youtil.Exception.UserException;
+
+import com.youtil.Exception.ExceptionResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class UserExceptionController {
+
+    @ExceptionHandler(UserException.UserNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> userNotFoundException(
+            UserException.UserNotFoundException e) {
+        ExceptionResponse response = new ExceptionResponse();
+        response.setCode("400");
+        response.setMessage(e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/youtil/Model/Interview.java
+++ b/src/main/java/com/youtil/Model/Interview.java
@@ -1,5 +1,6 @@
 package com.youtil.Model;
 
+import com.youtil.Common.Enums.Level;
 import com.youtil.Common.Enums.Status;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -15,7 +16,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.logging.Level;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,8 +46,6 @@ public class Interview extends BaseTime {
     @Column(nullable = false)
     private Level level;
 
-    @Column(nullable = false)
-    private Boolean isDeleted = false;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/youtil/Repository/TilRepository.java
+++ b/src/main/java/com/youtil/Repository/TilRepository.java
@@ -2,7 +2,10 @@ package com.youtil.Repository;
 
 import com.youtil.Model.Til;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-public interface TilRepository extends JpaRepository<Til, Long> {
+@Repository
+public interface TilRepository extends JpaRepository<Til, Long>, TilRepositoryCustom {
+
 
 }

--- a/src/main/java/com/youtil/Repository/TilRepositoryCustom.java
+++ b/src/main/java/com/youtil/Repository/TilRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.youtil.Repository;
+
+import com.youtil.Model.Til;
+import java.util.List;
+
+public interface TilRepositoryCustom {
+
+    List<Til> findAllByUserIdAndYear(long userId, int year);
+}

--- a/src/main/java/com/youtil/Repository/TilRepositoryImpl.java
+++ b/src/main/java/com/youtil/Repository/TilRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.youtil.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import static com.youtil.Model.QTil.til;
+import com.youtil.Model.Til;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TilRepositoryImpl implements TilRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Til> findAllByUserIdAndYear(long userId, int year) {
+        return queryFactory.selectFrom(til)
+                .where(
+                        til.user.id.eq(userId),
+                        til.createdAt.year().eq(year)
+                )
+                .fetch();
+
+    }
+}

--- a/src/main/java/com/youtil/Util/EntityValidator.java
+++ b/src/main/java/com/youtil/Util/EntityValidator.java
@@ -1,0 +1,23 @@
+package com.youtil.Util;
+
+import com.youtil.Common.Enums.Status;
+import com.youtil.Exception.UserException.UserException.UserNotFoundException;
+import com.youtil.Model.User;
+import com.youtil.Repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EntityValidator {
+
+    private final UserRepository userRepository;
+
+
+    public User getValidUserOrThrow(long userId) {
+        return userRepository.findById(userId)
+                .filter(user -> user.getStatus() == Status.active)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+}

--- a/src/main/java/com/youtil/Util/JwtUtil.java
+++ b/src/main/java/com/youtil/Util/JwtUtil.java
@@ -1,8 +1,6 @@
 package com.youtil.Util;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -17,6 +15,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class JwtUtil {
+
     private static String SECRET_KEY;
     private static Long ACCESS_TOKEN_EXPIRATION;
     private static Long REFRESH_TOKEN_EXPIRATION;
@@ -49,7 +48,7 @@ public class JwtUtil {
                 .compact();
     }
 
-    public static String getAuthenticatedUserId() {
+    public static long getAuthenticatedUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null) {
@@ -57,13 +56,12 @@ public class JwtUtil {
         }
 
         log.info("Authenticated userId: {}", authentication.getName());
-        return authentication.getName();
+        return Long.valueOf(authentication.getName());
     }
 
     private Key getSigningKey() {
         return Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
     }
-
 
 
     // 토큰 검증
@@ -74,8 +72,6 @@ public class JwtUtil {
                 .parseClaimsJws(token)
                 .getBody();
     }
-
-
 
 
 }


### PR DESCRIPTION
- 제목 : feat(i16): 유저 정보조회 / 유저탈퇴 / 유저 TIL 횟수 기록 조회 추가

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이

- 구현되었는지 설명해주세요
- 유저 정보조회 / 유저탈퇴 / 유저 TIL 횟수 기록 조회 API 구현
- QueryDSL 도입

  <br/>

## 🔧 앞으로의 과제

- 할 일을 적어주세요
- 해당 유저의 공유된 TIL 조회

  <br/>

## ➕ 이슈

Closes #16 


<br/>
