### PR TITLE
[feat] 뉴스 도메인 테스트 코드 작성

### DIFF
--- a/src/main/java/com/youtil/Api/Storage/Service/StorageService.java
+++ b/src/main/java/com/youtil/Api/Storage/Service/StorageService.java
@@ -4,11 +4,10 @@ package com.youtil.Api.Storage.Service;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.youtil.Api.Storage.Dto.StorageResponseDTO.ImageUploadResponse;
+import com.youtil.Exception.StorageException.StorageException;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.UUID;
-
-import com.youtil.Exception.StorageException.StorageException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/src/test/java/com/youtil/Constants/MockNewsConstants.java
+++ b/src/test/java/com/youtil/Constants/MockNewsConstants.java
@@ -1,0 +1,14 @@
+package com.youtil.Constants;
+
+public class MockNewsConstants {
+
+    public static final long NEWS_ID = 1;
+    public static String NEWS_TITLE = "title";
+    public static String NEWS_CONTENT = "content";
+    public static String NEWS_ORIGINAL_URL = "originalUrl";
+    public static String NEWS_THUMBNAIL = "thumbnail";
+
+    private MockNewsConstants() {
+    }
+
+}

--- a/src/test/java/com/youtil/Constants/NewsServiceConstants.java
+++ b/src/test/java/com/youtil/Constants/NewsServiceConstants.java
@@ -1,0 +1,26 @@
+package com.youtil.Constants;
+
+public class NewsServiceConstants {
+
+    public static final String BASE_URL = "https://mock.domain.com";
+    public static final String MOCK_NEWS_URL = "http://example.com/news";
+    public static final String MOCK_PUB_DATE = "2024-04-01 10:00:00";
+    public static final String ORIGINAL_TITLE = "Original title";
+    public static final String TRANSLATED_TITLE = "번역된 제목";
+    public static final String DEFAULT_DESCRIPTION = "요약 내용";
+
+    public static final String PATH_RESULTS = "results";
+    public static final String PATH_DUPLICATE = "duplicate";
+    public static final String PATH_LINK = "link";
+    public static final String PATH_PUB_DATE = "pubDate";
+    public static final String PATH_TITLE = "title";
+    public static final String PATH_DESCRIPTION = "description";
+    public static final String PATH_IMAGE_URL = "image_url";
+    public static final String FALLBACK_DESCRIPTION = "요약본 미제공";
+    public static final String DEFAULT_IMAGE_URL = "https://example.com/image.jpg";
+    public static final String TARGET_LANG = "ko";
+
+    private NewsServiceConstants() {
+    }
+
+}

--- a/src/test/java/com/youtil/Constants/NewsServiceTestConstants.java
+++ b/src/test/java/com/youtil/Constants/NewsServiceTestConstants.java
@@ -1,6 +1,6 @@
 package com.youtil.Constants;
 
-public class NewsServiceConstants {
+public class NewsServiceTestConstants {
 
     public static final String BASE_URL = "https://mock.domain.com";
     public static final String MOCK_NEWS_URL = "http://example.com/news";
@@ -20,7 +20,7 @@ public class NewsServiceConstants {
     public static final String DEFAULT_IMAGE_URL = "https://example.com/image.jpg";
     public static final String TARGET_LANG = "ko";
 
-    private NewsServiceConstants() {
+    private NewsServiceTestConstants() {
     }
 
 }

--- a/src/test/java/com/youtil/Mock/MockNewsBuilder.java
+++ b/src/test/java/com/youtil/Mock/MockNewsBuilder.java
@@ -1,0 +1,24 @@
+package com.youtil.Mock;
+
+import static com.youtil.Constants.MockNewsConstants.NEWS_CONTENT;
+import static com.youtil.Constants.MockNewsConstants.NEWS_ID;
+import static com.youtil.Constants.MockNewsConstants.NEWS_ORIGINAL_URL;
+import static com.youtil.Constants.MockNewsConstants.NEWS_THUMBNAIL;
+import static com.youtil.Constants.MockNewsConstants.NEWS_TITLE;
+import com.youtil.Model.News;
+import java.time.OffsetDateTime;
+
+public class MockNewsBuilder {
+
+    public static News createNews() {
+        News news = News.builder()
+                .id(NEWS_ID)
+                .title(NEWS_TITLE)
+                .content(NEWS_CONTENT)
+                .originUrl(NEWS_ORIGINAL_URL)
+                .thumbnail(NEWS_THUMBNAIL)
+                .createdAt(OffsetDateTime.now())
+                .build();
+        return news;
+    }
+}

--- a/src/test/java/com/youtil/News/Service/NewsServiceTest.java
+++ b/src/test/java/com/youtil/News/Service/NewsServiceTest.java
@@ -1,4 +1,241 @@
 package com.youtil.News.Service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.youtil.Api.News.Dto.NewsResponseDTO.GetNewsResponse;
+import com.youtil.Api.News.Service.NewsService;
+import com.youtil.Api.News.Service.TranslationService;
+import com.youtil.Config.AppProperties;
+import com.youtil.Model.News;
+import com.youtil.Repository.NewsRepository;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.assertj.core.util.Lists;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+
+@ExtendWith(MockitoExtension.class)
 public class NewsServiceTest {
+
+    @Mock
+    private NewsRepository newsRepository;
+    @InjectMocks
+    private NewsService newsService;
+    @Mock
+    private WebClient webClient;
+    @Mock
+    private AppProperties appProperties;
+    @Mock
+    private TranslationService translationService;
+    private News mockNews;
+    private WebClient.RequestHeadersUriSpec getUriSpec;
+    private WebClient.RequestHeadersSpec getHeaderSpec;
+    private WebClient.ResponseSpec getResponseSpec;
+
+    News createNews() {
+        News news = News.builder()
+                .id(1L)
+                .title("title")
+                .content("content")
+                .originUrl("originUrl")
+                .thumbnail("thumbnail")
+                .createdAt(OffsetDateTime.now())
+                .build();
+        return news;
+    }
+
+    private void setupWebClient() {
+        // GET - Email 정보와 유저 정보
+        getUriSpec = mock(WebClient.RequestHeadersUriSpec.class);
+
+        getHeaderSpec = mock(WebClient.RequestHeadersSpec.class);
+
+        getResponseSpec = mock(WebClient.ResponseSpec.class);
+
+        //처음 get을 호출하면 이메일, 두번째 호출하면 user 정보로 규정한다.
+        when(webClient.get())
+                .thenReturn(getUriSpec);
+    }
+
+
+    @BeforeEach()
+    void setUp() {
+        mockNews = createNews();
+
+    }
+
+    @Test
+    @DisplayName("뉴스 조회 - 뉴스가 있을 경우 - 뉴스 조회 성공")
+    void getNews_withValidNews_success() {
+        when(appProperties.getServerDomain()).thenReturn("https://mock.domain.com");
+        List<News> tempList = Lists.newArrayList(mockNews, mockNews);
+        when(newsRepository.findAllByOrderByCreatedAtDesc()).thenReturn(tempList);
+
+        GetNewsResponse getNewsResponse = newsService.getNewsService();
+        assertEquals(tempList.get(0).getTitle(), getNewsResponse.getNews().get(0).getTitle());
+
+    }
+
+    @Test
+    @DisplayName("뉴스 조회 - 뉴스가 없을 경우 - 뉴스 조회 성공")
+    void getNews_withInvalidNews_success() {
+        when(appProperties.getServerDomain()).thenReturn("https://mock.domain.com");
+        when(newsRepository.findAllByOrderByCreatedAtDesc()).thenReturn(Collections.emptyList());
+        GetNewsResponse getNewsResponse = newsService.getNewsService();
+        assertNotNull(getNewsResponse);
+        assertTrue(getNewsResponse.getNews().isEmpty());
+    }
+
+    //뉴스 생성
+    @Test
+    @DisplayName("뉴스 생성 - 저장되어 있는 데이터가 10개 미만인 경우 - 뉴스 생성 성공")
+    void createNews_withDataMaxThanTen_success() {
+        // given
+        JsonNode mockResponse = mock(JsonNode.class);
+        JsonNode mockResults = mock(JsonNode.class);
+        JsonNode mockResultItem = mock(JsonNode.class);
+
+        // 각 필드에 대한 JsonNode mock
+        JsonNode duplicateNode = mock(JsonNode.class);
+        JsonNode linkNode = mock(JsonNode.class);
+        JsonNode pubDateNode = mock(JsonNode.class);
+        JsonNode titleNode = mock(JsonNode.class);
+        JsonNode descriptionNode = mock(JsonNode.class);
+        JsonNode imageUrlNode = mock(JsonNode.class);
+
+        // 저장된 뉴스는 4개
+        when(newsRepository.count()).thenReturn(4L);
+
+        //  mock 체인 구성
+        setupWebClient();
+        when(getUriSpec.uri(any(Function.class))).thenReturn(getHeaderSpec);
+        when(getHeaderSpec.retrieve()).thenReturn(getResponseSpec);
+        when(getResponseSpec.bodyToMono(eq(JsonNode.class))).thenReturn(Mono.just(mockResponse));
+
+        // mockResultItem 하나만 있다고 가정
+        when(mockResponse.path("results")).thenReturn(mockResults);
+        when(mockResults.isArray()).thenReturn(true);
+        when(mockResults.iterator()).thenReturn(List.of(mockResultItem).iterator());
+
+        //뉴스 데이터 및  번역 Mock Chaining
+        when(mockResultItem.path("duplicate")).thenReturn(duplicateNode);
+        when(duplicateNode.asBoolean(false)).thenReturn(false);
+
+        when(mockResultItem.path("link")).thenReturn(linkNode);
+        when(linkNode.asText(null)).thenReturn("http://example.com/news");
+
+        when(newsRepository.existsByOriginUrl("http://example.com/news")).thenReturn(false);
+
+        when(mockResultItem.path("pubDate")).thenReturn(pubDateNode);
+        when(pubDateNode.asText(null)).thenReturn("2024-04-01 10:00:00");
+
+        when(mockResultItem.path("title")).thenReturn(titleNode);
+        when(titleNode.asText(null)).thenReturn("Original title");
+
+        when(translationService.translateText("Original title", "ko")).thenReturn("번역된 제목");
+
+        when(mockResultItem.path("description")).thenReturn(descriptionNode);
+        when(descriptionNode.asText("요약본 미제공")).thenReturn("요약 내용");
+
+        when(mockResultItem.path("image_url")).thenReturn(imageUrlNode);
+        when(imageUrlNode.asText(null)).thenReturn("https://example.com/image.jpg");
+
+        newsService.createNewsService();
+
+        verify(newsRepository, times(1)).save(any(News.class));
+        verify(newsRepository, never()).deleteAll(any());
+    }
+
+
+    @Test
+    @DisplayName("뉴스 생성 - 저장되있는 데이터가 10개 이상일 경우 - 뉴스 생성 성공")
+    void createNews_withDataMinThanTen_success() {
+        JsonNode mockResponse = mock(JsonNode.class);
+        JsonNode mockResults = mock(JsonNode.class);
+        JsonNode mockResultItem = mock(JsonNode.class);
+
+        JsonNode duplicateNode = mock(JsonNode.class);
+        JsonNode linkNode = mock(JsonNode.class);
+        JsonNode pubDateNode = mock(JsonNode.class);
+        JsonNode titleNode = mock(JsonNode.class);
+        JsonNode descriptionNode = mock(JsonNode.class);
+        JsonNode imageUrlNode = mock(JsonNode.class);
+
+        when(newsRepository.count()).thenReturn(11L);
+
+        setupWebClient();
+        when(getUriSpec.uri(any(Function.class))).thenReturn(getHeaderSpec);
+        when(getHeaderSpec.retrieve()).thenReturn(getResponseSpec);
+        when(getResponseSpec.bodyToMono(eq(JsonNode.class))).thenReturn(Mono.just(mockResponse));
+
+        when(mockResponse.path("results")).thenReturn(mockResults);
+        when(mockResults.isArray()).thenReturn(true);
+        when(mockResults.iterator()).thenReturn(List.of(mockResultItem).iterator());
+
+        when(mockResultItem.path("duplicate")).thenReturn(duplicateNode);
+        when(duplicateNode.asBoolean(false)).thenReturn(false);
+        when(mockResultItem.path("link")).thenReturn(linkNode);
+        when(linkNode.asText(null)).thenReturn("https://example.com/news");
+        when(newsRepository.existsByOriginUrl("https://example.com/news")).thenReturn(false);
+        when(mockResultItem.path("pubDate")).thenReturn(pubDateNode);
+        when(pubDateNode.asText(null)).thenReturn("2024-04-01 10:00:00");
+        when(mockResultItem.path("title")).thenReturn(titleNode);
+        when(titleNode.asText(null)).thenReturn("Original title");
+        when(translationService.translateText("Original title", "ko")).thenReturn("번역된 제목");
+
+        when(mockResultItem.path("description")).thenReturn(descriptionNode);
+        when(descriptionNode.asText("요약본 미제공")).thenReturn("요약 내용");
+
+        when(mockResultItem.path("image_url")).thenReturn(imageUrlNode);
+        when(imageUrlNode.asText(null)).thenReturn("https://example.com/image.jpg");
+
+        News oldNews = News.builder()
+                .id(30L)
+                .title("old")
+                .originUrl("http://example.com/old")
+                .createdAt(OffsetDateTime.parse("2023-01-01T00:00:00+00:00"))
+                .build();
+        when(newsRepository.findAll(
+                PageRequest.of(0, (int) (newsRepository.count() - 10),
+                        Sort.by(Direction.ASC, "createdAt")))
+        ).thenReturn(new PageImpl<>(List.of(oldNews)));
+
+        newsService.createNewsService();
+
+        verify(newsRepository, times(1)).save(any(News.class));
+        verify(newsRepository, times(1)).deleteAll(
+                argThat(iterable -> {
+                    List<News> newsList = StreamSupport.stream(iterable.spliterator(), false)
+                            .collect(Collectors.toList());
+                    return newsList.contains(oldNews) && newsList.size() == 1;
+                })
+        );
+    }
+    
 }

--- a/src/test/java/com/youtil/News/Service/NewsServiceTest.java
+++ b/src/test/java/com/youtil/News/Service/NewsServiceTest.java
@@ -70,19 +70,8 @@ public class NewsServiceTest {
         return news;
     }
 
-    private void setupWebClient() {
-        // GET - Email 정보와 유저 정보
-        getUriSpec = mock(WebClient.RequestHeadersUriSpec.class);
 
-        getHeaderSpec = mock(WebClient.RequestHeadersSpec.class);
-
-        getResponseSpec = mock(WebClient.ResponseSpec.class);
-
-        //처음 get을 호출하면 이메일, 두번째 호출하면 user 정보로 규정한다.
-        when(webClient.get())
-                .thenReturn(getUriSpec);
-    }
-
+    //JsonNode 모킹
     private void setupMockNewsJsonNode(JsonNode mockResponse, JsonNode mockResults,
             JsonNode mockResultItem,
             String url, String pubDate) {
@@ -118,8 +107,17 @@ public class NewsServiceTest {
         when(imageUrlNode.asText(null)).thenReturn("https://example.com/image.jpg");
     }
 
+    //웹클라이언트 모킹
     private void setupWebClientMock(JsonNode mockResponse) {
-        setupWebClient();
+        getUriSpec = mock(WebClient.RequestHeadersUriSpec.class);
+
+        getHeaderSpec = mock(WebClient.RequestHeadersSpec.class);
+
+        getResponseSpec = mock(WebClient.ResponseSpec.class);
+
+        when(webClient.get())
+                .thenReturn(getUriSpec);
+
         when(getUriSpec.uri(any(Function.class))).thenReturn(getHeaderSpec);
         when(getHeaderSpec.retrieve()).thenReturn(getResponseSpec);
         when(getResponseSpec.bodyToMono(eq(JsonNode.class))).thenReturn(Mono.just(mockResponse));
@@ -128,7 +126,6 @@ public class NewsServiceTest {
     @BeforeEach()
     void setUp() {
         mockNews = createNews();
-
     }
 
     @Test

--- a/src/test/java/com/youtil/News/Service/NewsServiceTest.java
+++ b/src/test/java/com/youtil/News/Service/NewsServiceTest.java
@@ -43,6 +43,7 @@ import reactor.core.publisher.Mono;
 @ExtendWith(MockitoExtension.class)
 public class NewsServiceTest {
 
+    private final String BASE_URL = "https://mock.domain.com";
     @Mock
     private NewsRepository newsRepository;
     @InjectMocks
@@ -131,7 +132,7 @@ public class NewsServiceTest {
     @Test
     @DisplayName("뉴스 조회 - 뉴스가 있을 경우 - 뉴스 조회 성공")
     void getNews_withValidNews_success() {
-        when(appProperties.getServerDomain()).thenReturn("https://mock.domain.com");
+        when(appProperties.getServerDomain()).thenReturn(BASE_URL);
         List<News> tempList = Lists.newArrayList(mockNews, mockNews);
         when(newsRepository.findAllByOrderByCreatedAtDesc()).thenReturn(tempList);
 
@@ -143,7 +144,7 @@ public class NewsServiceTest {
     @Test
     @DisplayName("뉴스 조회 - 뉴스가 없을 경우 - 뉴스 조회 성공")
     void getNews_withInvalidNews_success() {
-        when(appProperties.getServerDomain()).thenReturn("https://mock.domain.com");
+        when(appProperties.getServerDomain()).thenReturn(BASE_URL);
         when(newsRepository.findAllByOrderByCreatedAtDesc()).thenReturn(Collections.emptyList());
         GetNewsResponse getNewsResponse = newsService.getNewsService();
         assertNotNull(getNewsResponse);

--- a/src/test/java/com/youtil/News/Service/NewsServiceTest.java
+++ b/src/test/java/com/youtil/News/Service/NewsServiceTest.java
@@ -5,6 +5,23 @@ import com.youtil.Api.News.Dto.NewsResponseDTO.GetNewsResponse;
 import com.youtil.Api.News.Service.NewsService;
 import com.youtil.Api.News.Service.TranslationService;
 import com.youtil.Config.AppProperties;
+import static com.youtil.Constants.NewsServiceConstants.BASE_URL;
+import static com.youtil.Constants.NewsServiceConstants.DEFAULT_DESCRIPTION;
+import static com.youtil.Constants.NewsServiceConstants.DEFAULT_IMAGE_URL;
+import static com.youtil.Constants.NewsServiceConstants.FALLBACK_DESCRIPTION;
+import static com.youtil.Constants.NewsServiceConstants.MOCK_NEWS_URL;
+import static com.youtil.Constants.NewsServiceConstants.MOCK_PUB_DATE;
+import static com.youtil.Constants.NewsServiceConstants.ORIGINAL_TITLE;
+import static com.youtil.Constants.NewsServiceConstants.PATH_DESCRIPTION;
+import static com.youtil.Constants.NewsServiceConstants.PATH_DUPLICATE;
+import static com.youtil.Constants.NewsServiceConstants.PATH_IMAGE_URL;
+import static com.youtil.Constants.NewsServiceConstants.PATH_LINK;
+import static com.youtil.Constants.NewsServiceConstants.PATH_PUB_DATE;
+import static com.youtil.Constants.NewsServiceConstants.PATH_RESULTS;
+import static com.youtil.Constants.NewsServiceConstants.PATH_TITLE;
+import static com.youtil.Constants.NewsServiceConstants.TARGET_LANG;
+import static com.youtil.Constants.NewsServiceConstants.TRANSLATED_TITLE;
+import static com.youtil.Mock.MockNewsBuilder.createNews;
 import com.youtil.Model.News;
 import com.youtil.Repository.NewsRepository;
 import java.time.OffsetDateTime;
@@ -43,7 +60,6 @@ import reactor.core.publisher.Mono;
 @ExtendWith(MockitoExtension.class)
 public class NewsServiceTest {
 
-    private final String BASE_URL = "https://mock.domain.com";
     @Mock
     private NewsRepository newsRepository;
     @InjectMocks
@@ -59,23 +75,11 @@ public class NewsServiceTest {
     private WebClient.RequestHeadersSpec getHeaderSpec;
     private WebClient.ResponseSpec getResponseSpec;
 
-    News createNews() {
-        News news = News.builder()
-                .id(1L)
-                .title("title")
-                .content("content")
-                .originUrl("originUrl")
-                .thumbnail("thumbnail")
-                .createdAt(OffsetDateTime.now())
-                .build();
-        return news;
-    }
-
 
     //JsonNode 모킹
     private void setupMockNewsJsonNode(JsonNode mockResponse, JsonNode mockResults,
-            JsonNode mockResultItem,
-            String url, String pubDate) {
+            JsonNode mockResultItem, String url, String pubDate) {
+
         JsonNode duplicateNode = mock(JsonNode.class);
         JsonNode linkNode = mock(JsonNode.class);
         JsonNode pubDateNode = mock(JsonNode.class);
@@ -83,29 +87,30 @@ public class NewsServiceTest {
         JsonNode descriptionNode = mock(JsonNode.class);
         JsonNode imageUrlNode = mock(JsonNode.class);
 
-        when(mockResponse.path("results")).thenReturn(mockResults);
+        when(mockResponse.path(PATH_RESULTS)).thenReturn(mockResults);
         when(mockResults.isArray()).thenReturn(true);
         when(mockResults.iterator()).thenReturn(List.of(mockResultItem).iterator());
 
-        when(mockResultItem.path("duplicate")).thenReturn(duplicateNode);
+        when(mockResultItem.path(PATH_DUPLICATE)).thenReturn(duplicateNode);
         when(duplicateNode.asBoolean(false)).thenReturn(false);
 
-        when(mockResultItem.path("link")).thenReturn(linkNode);
+        when(mockResultItem.path(PATH_LINK)).thenReturn(linkNode);
         when(linkNode.asText(null)).thenReturn(url);
         when(newsRepository.existsByOriginUrl(url)).thenReturn(false);
 
-        when(mockResultItem.path("pubDate")).thenReturn(pubDateNode);
+        when(mockResultItem.path(PATH_PUB_DATE)).thenReturn(pubDateNode);
         when(pubDateNode.asText(null)).thenReturn(pubDate);
 
-        when(mockResultItem.path("title")).thenReturn(titleNode);
-        when(titleNode.asText(null)).thenReturn("Original title");
-        when(translationService.translateText("Original title", "ko")).thenReturn("번역된 제목");
+        when(mockResultItem.path(PATH_TITLE)).thenReturn(titleNode);
+        when(titleNode.asText(null)).thenReturn(ORIGINAL_TITLE);
+        when(translationService.translateText(ORIGINAL_TITLE, TARGET_LANG)).thenReturn(
+                TRANSLATED_TITLE);
 
-        when(mockResultItem.path("description")).thenReturn(descriptionNode);
-        when(descriptionNode.asText("요약본 미제공")).thenReturn("요약 내용");
+        when(mockResultItem.path(PATH_DESCRIPTION)).thenReturn(descriptionNode);
+        when(descriptionNode.asText(FALLBACK_DESCRIPTION)).thenReturn(DEFAULT_DESCRIPTION);
 
-        when(mockResultItem.path("image_url")).thenReturn(imageUrlNode);
-        when(imageUrlNode.asText(null)).thenReturn("https://example.com/image.jpg");
+        when(mockResultItem.path(PATH_IMAGE_URL)).thenReturn(imageUrlNode);
+        when(imageUrlNode.asText(null)).thenReturn(DEFAULT_IMAGE_URL);
     }
 
     //웹클라이언트 모킹
@@ -155,14 +160,15 @@ public class NewsServiceTest {
     @Test
     @DisplayName("뉴스 생성 - 10개 미만 - 성공")
     void createNews_withDataMaxThanTen_success() {
+        final long NEWS_COUNT = 4L;
         JsonNode mockResponse = mock(JsonNode.class);
         JsonNode mockResults = mock(JsonNode.class);
         JsonNode mockResultItem = mock(JsonNode.class);
 
-        when(newsRepository.count()).thenReturn(4L);
+        when(newsRepository.count()).thenReturn(NEWS_COUNT);
         setupWebClientMock(mockResponse);
         setupMockNewsJsonNode(mockResponse, mockResults, mockResultItem,
-                "http://example.com/news", "2024-04-01 10:00:00");
+                MOCK_NEWS_URL, MOCK_PUB_DATE);
 
         newsService.createNewsService();
 
@@ -174,23 +180,32 @@ public class NewsServiceTest {
     @Test
     @DisplayName("뉴스 생성 - 저장되있는 데이터가 10개 이상일 경우 - 뉴스 생성 성공")
     void createNews_withDataMinThanTen_success() {
+        final long NEWS_COUNT = 11L;
+        final long OLD_NEWS_ID = 30L;
+        final String OLD_NEWS_TITLE = "old";
+        final String OLD_NEWS_URL = "http://example.com/old";
+        final String OLD_NEWS_PUB_DATE = "2023-01-01T00:00:00+00:00";
+        final int pageNumber = 0;
+        final int pageSize = 1;
+        final String properties = "createdAt";
+
         JsonNode mockResponse = mock(JsonNode.class);
         JsonNode mockResults = mock(JsonNode.class);
         JsonNode mockResultItem = mock(JsonNode.class);
 
-        when(newsRepository.count()).thenReturn(11L);
+        when(newsRepository.count()).thenReturn(NEWS_COUNT);
         setupWebClientMock(mockResponse);
         setupMockNewsJsonNode(mockResponse, mockResults, mockResultItem,
-                "https://example.com/news", "2024-04-01 10:00:00");
+                MOCK_NEWS_URL, MOCK_PUB_DATE);
 
         News oldNews = News.builder()
-                .id(30L)
-                .title("old")
-                .originUrl("http://example.com/old")
-                .createdAt(OffsetDateTime.parse("2023-01-01T00:00:00+00:00"))
+                .id(OLD_NEWS_ID)
+                .title(OLD_NEWS_TITLE)
+                .originUrl(OLD_NEWS_URL)
+                .createdAt(OffsetDateTime.parse(OLD_NEWS_PUB_DATE))
                 .build();
         when(newsRepository.findAll(
-                PageRequest.of(0, 1, Sort.by(Direction.ASC, "createdAt")))
+                PageRequest.of(pageNumber, pageSize, Sort.by(Direction.ASC, properties)))
         ).thenReturn(new PageImpl<>(List.of(oldNews)));
 
         newsService.createNewsService();
@@ -200,7 +215,7 @@ public class NewsServiceTest {
                 argThat(iterable -> {
                     List<News> newsList = StreamSupport.stream(iterable.spliterator(), false)
                             .collect(Collectors.toList());
-                    return newsList.contains(oldNews) && newsList.size() == 1;
+                    return newsList.contains(oldNews) && newsList.size() == pageSize;
                 })
         );
 

--- a/src/test/java/com/youtil/News/Service/NewsServiceTest.java
+++ b/src/test/java/com/youtil/News/Service/NewsServiceTest.java
@@ -23,11 +23,11 @@ import static com.youtil.Constants.NewsServiceTestConstants.TRANSLATED_TITLE;
 import static com.youtil.Mock.MockNewsBuilder.createNews;
 import com.youtil.Model.News;
 import com.youtil.Repository.NewsRepository;
+import com.youtil.Util.MockUtil;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import static org.mockito.Mockito.mock;
@@ -55,7 +54,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -72,9 +70,6 @@ public class NewsServiceTest {
     @Mock
     private TranslationService translationService;
     private News mockNews;
-    private WebClient.RequestHeadersUriSpec getUriSpec;
-    private WebClient.RequestHeadersSpec getHeaderSpec;
-    private WebClient.ResponseSpec getResponseSpec;
 
 
     @BeforeEach()
@@ -130,7 +125,7 @@ public class NewsServiceTest {
         JsonNode mockResponse = mock(JsonNode.class);
         JsonNode mockResults = mock(JsonNode.class);
         when(newsRepository.count()).thenReturn(NEWS_COUNT);
-        setupWebClientMock(mockResponse);
+        MockUtil.setupWebClientWithJsonNodeMock(webClient, mockResponse);
         setupMockNewsJsonNode(mockResponse, mockResults, NEW_NEWS_COUNT);
 
         newsService.createNewsService();
@@ -164,7 +159,7 @@ public class NewsServiceTest {
         //본 로직은 마지막에 데이터가 10개 넘는다면 삭제하는 로직을 추가한다. 따라서 기존 뉴스데이터와 추가 뉴스데이터 개수를 더해서 리턴한다.
         when(newsRepository.count()).thenReturn(CURRENT_NEWS_COUNT + ADD_NEWS_COUNT);
 
-        setupWebClientMock(mockResponse);
+        MockUtil.setupWebClientWithJsonNodeMock(webClient, mockResponse);
         setupMockNewsJsonNode(mockResponse, mockResults, ADD_NEWS_COUNT);
 
         //삭제할 오래된 뉴스 리스트
@@ -247,21 +242,5 @@ public class NewsServiceTest {
         }
     }
 
-
-    //웹클라이언트 모킹
-    private void setupWebClientMock(JsonNode mockResponse) {
-        getUriSpec = mock(WebClient.RequestHeadersUriSpec.class);
-
-        getHeaderSpec = mock(WebClient.RequestHeadersSpec.class);
-
-        getResponseSpec = mock(WebClient.ResponseSpec.class);
-
-        when(webClient.get())
-                .thenReturn(getUriSpec);
-
-        when(getUriSpec.uri(any(Function.class))).thenReturn(getHeaderSpec);
-        when(getHeaderSpec.retrieve()).thenReturn(getResponseSpec);
-        when(getResponseSpec.bodyToMono(eq(JsonNode.class))).thenReturn(Mono.just(mockResponse));
-    }
 
 }

--- a/src/test/java/com/youtil/News/Service/NewsServiceTest.java
+++ b/src/test/java/com/youtil/News/Service/NewsServiceTest.java
@@ -10,8 +10,6 @@ import static com.youtil.Constants.NewsServiceConstants.BASE_URL;
 import static com.youtil.Constants.NewsServiceConstants.DEFAULT_DESCRIPTION;
 import static com.youtil.Constants.NewsServiceConstants.DEFAULT_IMAGE_URL;
 import static com.youtil.Constants.NewsServiceConstants.FALLBACK_DESCRIPTION;
-import static com.youtil.Constants.NewsServiceConstants.MOCK_NEWS_URL;
-import static com.youtil.Constants.NewsServiceConstants.MOCK_PUB_DATE;
 import static com.youtil.Constants.NewsServiceConstants.ORIGINAL_TITLE;
 import static com.youtil.Constants.NewsServiceConstants.PATH_DESCRIPTION;
 import static com.youtil.Constants.NewsServiceConstants.PATH_DUPLICATE;
@@ -26,10 +24,13 @@ import static com.youtil.Mock.MockNewsBuilder.createNews;
 import com.youtil.Model.News;
 import com.youtil.Repository.NewsRepository;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 import java.util.stream.StreamSupport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -124,18 +125,17 @@ public class NewsServiceTest {
     @DisplayName("뉴스 생성 - 10개 미만 - 성공")
     void createNews_withDataMaxThanTen_success() {
         final long NEWS_COUNT = 4L;
+        final long NEW_NEWS_COUNT = 2L;
+
         JsonNode mockResponse = mock(JsonNode.class);
         JsonNode mockResults = mock(JsonNode.class);
-        JsonNode mockResultItem = mock(JsonNode.class);
-
         when(newsRepository.count()).thenReturn(NEWS_COUNT);
         setupWebClientMock(mockResponse);
-        setupMockNewsJsonNode(mockResponse, mockResults, mockResultItem,
-                MOCK_NEWS_URL, MOCK_PUB_DATE);
+        setupMockNewsJsonNode(mockResponse, mockResults, NEW_NEWS_COUNT);
 
         newsService.createNewsService();
 
-        verify(newsRepository, times(1)).save(any(News.class));
+        verify(newsRepository, times((int) NEW_NEWS_COUNT)).save(any(News.class));
         verify(newsRepository, never()).deleteAll(any());
     }
 
@@ -143,83 +143,110 @@ public class NewsServiceTest {
     @Test
     @DisplayName("뉴스 생성 - 저장되있는 데이터가 10개 이상일 경우 - 뉴스 생성 성공")
     void createNews_withDataMinThanTen_success() {
-        final long NEWS_COUNT = 11L;
+        final long CURRENT_NEWS_COUNT = 10L;
+        final long ADD_NEWS_COUNT = 2L;
         final long OLD_NEWS_ID = 30L;
         final String OLD_NEWS_TITLE = "old";
         final String OLD_NEWS_URL = "http://example.com/old";
+
         final String OLD_NEWS_PUB_DATE = "2023-01-01T00:00:00+00:00";
-        final int pageNumber = 0;
-        final int pageSize = 1;
+
+        int pageNumber = 0;
+        //페이지 사이즈는 기존 뉴스 데이터들의 개수와, 앞으로 추가될 뉴스 데이터의 개수를 더한 뒤 10개보다 초과된 데이터의 개수를 저장한다.
+        int pageSize = (int) (CURRENT_NEWS_COUNT + ADD_NEWS_COUNT - 10);
         final String properties = "createdAt";
 
         JsonNode mockResponse = mock(JsonNode.class);
         JsonNode mockResults = mock(JsonNode.class);
-        JsonNode mockResultItem = mock(JsonNode.class);
 
-        when(newsRepository.count()).thenReturn(NEWS_COUNT);
+        //초기 모킹
+
+        //본 로직은 마지막에 데이터가 10개 넘는다면 삭제하는 로직을 추가한다. 따라서 기존 뉴스데이터와 추가 뉴스데이터 개수를 더해서 리턴한다.
+        when(newsRepository.count()).thenReturn(CURRENT_NEWS_COUNT + ADD_NEWS_COUNT);
+
         setupWebClientMock(mockResponse);
-        setupMockNewsJsonNode(mockResponse, mockResults, mockResultItem,
-                MOCK_NEWS_URL, MOCK_PUB_DATE);
+        setupMockNewsJsonNode(mockResponse, mockResults, ADD_NEWS_COUNT);
 
-        News oldNews = News.builder()
-                .id(OLD_NEWS_ID)
-                .title(OLD_NEWS_TITLE)
-                .originUrl(OLD_NEWS_URL)
-                .createdAt(OffsetDateTime.parse(OLD_NEWS_PUB_DATE))
-                .build();
+        //삭제할 오래도니 뉴스 리스트
+        List<News> oldNewsList = LongStream.range(0, pageSize)
+                .mapToObj(i -> News.builder()
+                        .id(OLD_NEWS_ID + i)
+                        .title(OLD_NEWS_TITLE + i)
+                        .originUrl(OLD_NEWS_URL + "/" + i)
+                        .createdAt(OffsetDateTime.parse(OLD_NEWS_PUB_DATE).minusDays(i))
+                        .build())
+                .collect(Collectors.toList());
+
         when(newsRepository.findAll(
                 PageRequest.of(pageNumber, pageSize, Sort.by(Direction.ASC, properties)))
-        ).thenReturn(new PageImpl<>(List.of(oldNews)));
+        ).thenReturn(new PageImpl<>(oldNewsList));
 
         newsService.createNewsService();
 
-        verify(newsRepository, times(1)).save(any(News.class));
-        verify(newsRepository, times(1)).deleteAll(
-                argThat(iterable -> {
-                    List<News> newsList = StreamSupport.stream(iterable.spliterator(), false)
-                            .collect(Collectors.toList());
-                    return newsList.contains(oldNews) && newsList.size() == pageSize;
-                })
-        );
+        verify(newsRepository, times(pageSize)).save(any(News.class));
+        //리스트를 삭제하기떄문에 딱 한번 호출되야함 더불어서 삭제되는 리스트가 의도한 리스트가 맞는지 확인
+        verify(newsRepository, times(1)).deleteAll(argThat(iterable ->
+                StreamSupport.stream(iterable.spliterator(), false)
+                        .toList()
+                        .equals(oldNewsList)
+        ));
 
     }
 
     //JsonNode 모킹
     private void setupMockNewsJsonNode(JsonNode mockResponse, JsonNode mockResults,
-            JsonNode mockResultItem, String url, String pubDate) {
+            long newsSize) {
 
-        JsonNode duplicateNode = mock(JsonNode.class);
-        JsonNode linkNode = mock(JsonNode.class);
-        JsonNode pubDateNode = mock(JsonNode.class);
-        JsonNode titleNode = mock(JsonNode.class);
-        JsonNode descriptionNode = mock(JsonNode.class);
-        JsonNode imageUrlNode = mock(JsonNode.class);
+        List<String> urls = new ArrayList<>();
+        List<String> pubDates = new ArrayList();
+        List<JsonNode> mockResultItems = IntStream.range(0, (int) newsSize)
+                .mapToObj(i -> mock(JsonNode.class))
+                .collect(Collectors.toList());
+
+        for (int i = 0; i < newsSize; i++) {
+            urls.add(mockNews.getOriginUrl() + i);
+            pubDates.add(mockNews.getCreatedAt().toString());
+        }
 
         when(mockResponse.path(PATH_RESULTS)).thenReturn(mockResults);
         when(mockResults.isArray()).thenReturn(true);
-        when(mockResults.iterator()).thenReturn(List.of(mockResultItem).iterator());
+        when(mockResults.iterator()).thenReturn(mockResultItems.iterator());
 
-        when(mockResultItem.path(PATH_DUPLICATE)).thenReturn(duplicateNode);
-        when(duplicateNode.asBoolean(false)).thenReturn(false);
+        for (int i = 0; i < mockResultItems.size(); i++) {
+            JsonNode item = mockResultItems.get(i);
+            String url = urls.get(i);
+            String pubDate = pubDates.get(i);
 
-        when(mockResultItem.path(PATH_LINK)).thenReturn(linkNode);
-        when(linkNode.asText(null)).thenReturn(url);
-        when(newsRepository.existsByOriginUrl(url)).thenReturn(false);
+            JsonNode duplicateNode = mock(JsonNode.class);
+            JsonNode linkNode = mock(JsonNode.class);
+            JsonNode pubDateNode = mock(JsonNode.class);
+            JsonNode titleNode = mock(JsonNode.class);
+            JsonNode descriptionNode = mock(JsonNode.class);
+            JsonNode imageUrlNode = mock(JsonNode.class);
 
-        when(mockResultItem.path(PATH_PUB_DATE)).thenReturn(pubDateNode);
-        when(pubDateNode.asText(null)).thenReturn(pubDate);
+            when(item.path(PATH_DUPLICATE)).thenReturn(duplicateNode);
+            when(duplicateNode.asBoolean(false)).thenReturn(false);
 
-        when(mockResultItem.path(PATH_TITLE)).thenReturn(titleNode);
-        when(titleNode.asText(null)).thenReturn(ORIGINAL_TITLE);
-        when(translationService.translateText(ORIGINAL_TITLE, TARGET_LANG)).thenReturn(
-                TRANSLATED_TITLE);
+            when(item.path(PATH_LINK)).thenReturn(linkNode);
+            when(linkNode.asText(null)).thenReturn(url);
+            when(newsRepository.existsByOriginUrl(url)).thenReturn(false);
 
-        when(mockResultItem.path(PATH_DESCRIPTION)).thenReturn(descriptionNode);
-        when(descriptionNode.asText(FALLBACK_DESCRIPTION)).thenReturn(DEFAULT_DESCRIPTION);
+            when(item.path(PATH_PUB_DATE)).thenReturn(pubDateNode);
+            when(pubDateNode.asText(null)).thenReturn(pubDate);
 
-        when(mockResultItem.path(PATH_IMAGE_URL)).thenReturn(imageUrlNode);
-        when(imageUrlNode.asText(null)).thenReturn(DEFAULT_IMAGE_URL);
+            when(item.path(PATH_TITLE)).thenReturn(titleNode);
+            when(titleNode.asText(null)).thenReturn(ORIGINAL_TITLE);
+            when(translationService.translateText(ORIGINAL_TITLE, TARGET_LANG))
+                    .thenReturn(TRANSLATED_TITLE);
+
+            when(item.path(PATH_DESCRIPTION)).thenReturn(descriptionNode);
+            when(descriptionNode.asText(FALLBACK_DESCRIPTION)).thenReturn(DEFAULT_DESCRIPTION);
+
+            when(item.path(PATH_IMAGE_URL)).thenReturn(imageUrlNode);
+            when(imageUrlNode.asText(null)).thenReturn(DEFAULT_IMAGE_URL);
+        }
     }
+
 
     //웹클라이언트 모킹
     private void setupWebClientMock(JsonNode mockResponse) {

--- a/src/test/java/com/youtil/News/Service/NewsServiceTest.java
+++ b/src/test/java/com/youtil/News/Service/NewsServiceTest.java
@@ -6,20 +6,20 @@ import com.youtil.Api.News.Dto.NewsResponseDTO.NewsItem;
 import com.youtil.Api.News.Service.NewsService;
 import com.youtil.Api.News.Service.TranslationService;
 import com.youtil.Config.AppProperties;
-import static com.youtil.Constants.NewsServiceConstants.BASE_URL;
-import static com.youtil.Constants.NewsServiceConstants.DEFAULT_DESCRIPTION;
-import static com.youtil.Constants.NewsServiceConstants.DEFAULT_IMAGE_URL;
-import static com.youtil.Constants.NewsServiceConstants.FALLBACK_DESCRIPTION;
-import static com.youtil.Constants.NewsServiceConstants.ORIGINAL_TITLE;
-import static com.youtil.Constants.NewsServiceConstants.PATH_DESCRIPTION;
-import static com.youtil.Constants.NewsServiceConstants.PATH_DUPLICATE;
-import static com.youtil.Constants.NewsServiceConstants.PATH_IMAGE_URL;
-import static com.youtil.Constants.NewsServiceConstants.PATH_LINK;
-import static com.youtil.Constants.NewsServiceConstants.PATH_PUB_DATE;
-import static com.youtil.Constants.NewsServiceConstants.PATH_RESULTS;
-import static com.youtil.Constants.NewsServiceConstants.PATH_TITLE;
-import static com.youtil.Constants.NewsServiceConstants.TARGET_LANG;
-import static com.youtil.Constants.NewsServiceConstants.TRANSLATED_TITLE;
+import static com.youtil.Constants.NewsServiceTestConstants.BASE_URL;
+import static com.youtil.Constants.NewsServiceTestConstants.DEFAULT_DESCRIPTION;
+import static com.youtil.Constants.NewsServiceTestConstants.DEFAULT_IMAGE_URL;
+import static com.youtil.Constants.NewsServiceTestConstants.FALLBACK_DESCRIPTION;
+import static com.youtil.Constants.NewsServiceTestConstants.ORIGINAL_TITLE;
+import static com.youtil.Constants.NewsServiceTestConstants.PATH_DESCRIPTION;
+import static com.youtil.Constants.NewsServiceTestConstants.PATH_DUPLICATE;
+import static com.youtil.Constants.NewsServiceTestConstants.PATH_IMAGE_URL;
+import static com.youtil.Constants.NewsServiceTestConstants.PATH_LINK;
+import static com.youtil.Constants.NewsServiceTestConstants.PATH_PUB_DATE;
+import static com.youtil.Constants.NewsServiceTestConstants.PATH_RESULTS;
+import static com.youtil.Constants.NewsServiceTestConstants.PATH_TITLE;
+import static com.youtil.Constants.NewsServiceTestConstants.TARGET_LANG;
+import static com.youtil.Constants.NewsServiceTestConstants.TRANSLATED_TITLE;
 import static com.youtil.Mock.MockNewsBuilder.createNews;
 import com.youtil.Model.News;
 import com.youtil.Repository.NewsRepository;
@@ -167,7 +167,7 @@ public class NewsServiceTest {
         setupWebClientMock(mockResponse);
         setupMockNewsJsonNode(mockResponse, mockResults, ADD_NEWS_COUNT);
 
-        //삭제할 오래도니 뉴스 리스트
+        //삭제할 오래된 뉴스 리스트
         List<News> oldNewsList = LongStream.range(0, pageSize)
                 .mapToObj(i -> News.builder()
                         .id(OLD_NEWS_ID + i)

--- a/src/test/java/com/youtil/News/Service/NewsServiceTest.java
+++ b/src/test/java/com/youtil/News/Service/NewsServiceTest.java
@@ -76,59 +76,6 @@ public class NewsServiceTest {
     private WebClient.ResponseSpec getResponseSpec;
 
 
-    //JsonNode 모킹
-    private void setupMockNewsJsonNode(JsonNode mockResponse, JsonNode mockResults,
-            JsonNode mockResultItem, String url, String pubDate) {
-
-        JsonNode duplicateNode = mock(JsonNode.class);
-        JsonNode linkNode = mock(JsonNode.class);
-        JsonNode pubDateNode = mock(JsonNode.class);
-        JsonNode titleNode = mock(JsonNode.class);
-        JsonNode descriptionNode = mock(JsonNode.class);
-        JsonNode imageUrlNode = mock(JsonNode.class);
-
-        when(mockResponse.path(PATH_RESULTS)).thenReturn(mockResults);
-        when(mockResults.isArray()).thenReturn(true);
-        when(mockResults.iterator()).thenReturn(List.of(mockResultItem).iterator());
-
-        when(mockResultItem.path(PATH_DUPLICATE)).thenReturn(duplicateNode);
-        when(duplicateNode.asBoolean(false)).thenReturn(false);
-
-        when(mockResultItem.path(PATH_LINK)).thenReturn(linkNode);
-        when(linkNode.asText(null)).thenReturn(url);
-        when(newsRepository.existsByOriginUrl(url)).thenReturn(false);
-
-        when(mockResultItem.path(PATH_PUB_DATE)).thenReturn(pubDateNode);
-        when(pubDateNode.asText(null)).thenReturn(pubDate);
-
-        when(mockResultItem.path(PATH_TITLE)).thenReturn(titleNode);
-        when(titleNode.asText(null)).thenReturn(ORIGINAL_TITLE);
-        when(translationService.translateText(ORIGINAL_TITLE, TARGET_LANG)).thenReturn(
-                TRANSLATED_TITLE);
-
-        when(mockResultItem.path(PATH_DESCRIPTION)).thenReturn(descriptionNode);
-        when(descriptionNode.asText(FALLBACK_DESCRIPTION)).thenReturn(DEFAULT_DESCRIPTION);
-
-        when(mockResultItem.path(PATH_IMAGE_URL)).thenReturn(imageUrlNode);
-        when(imageUrlNode.asText(null)).thenReturn(DEFAULT_IMAGE_URL);
-    }
-
-    //웹클라이언트 모킹
-    private void setupWebClientMock(JsonNode mockResponse) {
-        getUriSpec = mock(WebClient.RequestHeadersUriSpec.class);
-
-        getHeaderSpec = mock(WebClient.RequestHeadersSpec.class);
-
-        getResponseSpec = mock(WebClient.ResponseSpec.class);
-
-        when(webClient.get())
-                .thenReturn(getUriSpec);
-
-        when(getUriSpec.uri(any(Function.class))).thenReturn(getHeaderSpec);
-        when(getHeaderSpec.retrieve()).thenReturn(getResponseSpec);
-        when(getResponseSpec.bodyToMono(eq(JsonNode.class))).thenReturn(Mono.just(mockResponse));
-    }
-
     @BeforeEach()
     void setUp() {
         mockNews = createNews();
@@ -235,6 +182,59 @@ public class NewsServiceTest {
                 })
         );
 
+    }
+
+    //JsonNode 모킹
+    private void setupMockNewsJsonNode(JsonNode mockResponse, JsonNode mockResults,
+            JsonNode mockResultItem, String url, String pubDate) {
+
+        JsonNode duplicateNode = mock(JsonNode.class);
+        JsonNode linkNode = mock(JsonNode.class);
+        JsonNode pubDateNode = mock(JsonNode.class);
+        JsonNode titleNode = mock(JsonNode.class);
+        JsonNode descriptionNode = mock(JsonNode.class);
+        JsonNode imageUrlNode = mock(JsonNode.class);
+
+        when(mockResponse.path(PATH_RESULTS)).thenReturn(mockResults);
+        when(mockResults.isArray()).thenReturn(true);
+        when(mockResults.iterator()).thenReturn(List.of(mockResultItem).iterator());
+
+        when(mockResultItem.path(PATH_DUPLICATE)).thenReturn(duplicateNode);
+        when(duplicateNode.asBoolean(false)).thenReturn(false);
+
+        when(mockResultItem.path(PATH_LINK)).thenReturn(linkNode);
+        when(linkNode.asText(null)).thenReturn(url);
+        when(newsRepository.existsByOriginUrl(url)).thenReturn(false);
+
+        when(mockResultItem.path(PATH_PUB_DATE)).thenReturn(pubDateNode);
+        when(pubDateNode.asText(null)).thenReturn(pubDate);
+
+        when(mockResultItem.path(PATH_TITLE)).thenReturn(titleNode);
+        when(titleNode.asText(null)).thenReturn(ORIGINAL_TITLE);
+        when(translationService.translateText(ORIGINAL_TITLE, TARGET_LANG)).thenReturn(
+                TRANSLATED_TITLE);
+
+        when(mockResultItem.path(PATH_DESCRIPTION)).thenReturn(descriptionNode);
+        when(descriptionNode.asText(FALLBACK_DESCRIPTION)).thenReturn(DEFAULT_DESCRIPTION);
+
+        when(mockResultItem.path(PATH_IMAGE_URL)).thenReturn(imageUrlNode);
+        when(imageUrlNode.asText(null)).thenReturn(DEFAULT_IMAGE_URL);
+    }
+
+    //웹클라이언트 모킹
+    private void setupWebClientMock(JsonNode mockResponse) {
+        getUriSpec = mock(WebClient.RequestHeadersUriSpec.class);
+
+        getHeaderSpec = mock(WebClient.RequestHeadersSpec.class);
+
+        getResponseSpec = mock(WebClient.ResponseSpec.class);
+
+        when(webClient.get())
+                .thenReturn(getUriSpec);
+
+        when(getUriSpec.uri(any(Function.class))).thenReturn(getHeaderSpec);
+        when(getHeaderSpec.retrieve()).thenReturn(getResponseSpec);
+        when(getResponseSpec.bodyToMono(eq(JsonNode.class))).thenReturn(Mono.just(mockResponse));
     }
 
 }

--- a/src/test/java/com/youtil/News/Service/NewsServiceTest.java
+++ b/src/test/java/com/youtil/News/Service/NewsServiceTest.java
@@ -2,6 +2,7 @@ package com.youtil.News.Service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.youtil.Api.News.Dto.NewsResponseDTO.GetNewsResponse;
+import com.youtil.Api.News.Dto.NewsResponseDTO.NewsItem;
 import com.youtil.Api.News.Service.NewsService;
 import com.youtil.Api.News.Service.TranslationService;
 import com.youtil.Config.AppProperties;
@@ -30,7 +31,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.assertj.core.util.Lists;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -137,12 +137,28 @@ public class NewsServiceTest {
     @Test
     @DisplayName("뉴스 조회 - 뉴스가 있을 경우 - 뉴스 조회 성공")
     void getNews_withValidNews_success() {
-        when(appProperties.getServerDomain()).thenReturn(BASE_URL);
-        List<News> tempList = Lists.newArrayList(mockNews, mockNews);
-        when(newsRepository.findAllByOrderByCreatedAtDesc()).thenReturn(tempList);
+        final String PROXY_URL = BASE_URL + "/api/v1/news/image-proxy?url=";
 
-        GetNewsResponse getNewsResponse = newsService.getNewsService();
-        assertEquals(tempList.get(0).getTitle(), getNewsResponse.getNews().get(0).getTitle());
+        when(appProperties.getServerDomain()).thenReturn(BASE_URL);
+
+        List<News> newsList = List.of(mockNews, mockNews);
+        when(newsRepository.findAllByOrderByCreatedAtDesc()).thenReturn(newsList);
+
+        GetNewsResponse response = newsService.getNewsService();
+
+        List<NewsItem> result = response.getNews();
+        assertEquals(newsList.size(), result.size());
+
+        for (int i = 0; i < newsList.size(); i++) {
+            News source = newsList.get(i);
+            NewsItem target = result.get(i);
+
+            assertEquals(source.getTitle(), target.getTitle());
+            assertEquals(source.getContent(), target.getSummary());
+            assertEquals(source.getOriginUrl(), target.getLink());
+            assertEquals(PROXY_URL + source.getThumbnail(), target.getThumbnail());
+        }
+
 
     }
 

--- a/src/test/java/com/youtil/Util/MockUtil.java
+++ b/src/test/java/com/youtil/Util/MockUtil.java
@@ -1,0 +1,38 @@
+package com.youtil.Util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.function.Function;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+
+public class MockUtil {
+
+
+    //웹클라이언트 JsonNode모킹
+    public static void setupWebClientWithJsonNodeMock(WebClient webClient, JsonNode mockResponse) {
+
+        WebClient.RequestHeadersUriSpec getUriSpec;
+        WebClient.RequestHeadersSpec getHeaderSpec;
+        WebClient.ResponseSpec getResponseSpec;
+
+        getUriSpec = mock(WebClient.RequestHeadersUriSpec.class);
+
+        getHeaderSpec = mock(WebClient.RequestHeadersSpec.class);
+
+        getResponseSpec = mock(WebClient.ResponseSpec.class);
+
+        when(webClient.get())
+                .thenReturn(getUriSpec);
+
+        when(getUriSpec.uri(any(Function.class))).thenReturn(getHeaderSpec);
+        when(getHeaderSpec.retrieve()).thenReturn(getResponseSpec);
+        when(getResponseSpec.bodyToMono(eq(JsonNode.class))).thenReturn(Mono.just(mockResponse));
+    }
+}


### PR DESCRIPTION
- 제목 : feat(#114 ): 유저 도메인 테스트 코드 작성
 

## 🔘Part

- [x] BE jun : @jainefer 

  <br/>

## 🔎 작업 내용

- 뉴스 도메인의 비즈니스 로직에 대해 테스트 코드를 작성했습니다.
- 테스트 메서드 컨벤션은 카멜케이스와 스네이크 케이스를 혼용해서 메서드이름 _ 조건_결과의 형태로 네이밍했습니다
   - ex) loginUser_withValidCredentials_success()

<details>
<summary>🧪 테스트 시나리오 보기</summary>

## 1. 뉴스 조회

- 성공 시나리오
    - 뉴스 데이터가 성공적으로 가져와진다
    - 없다면 빈 배열로 보여준다

## 2. 뉴스 생성 (스케줄러 서비스)

- 성공 시나리오
    - 데이터가 10개 미만인 경우 - 뉴스 생성이 성공적으로 이루어진다.
    - 데이터가 10개 이상인 경우 - 오래된 데이터가 삭제되고, 뉴스 생성이 성공적으로 이루어진다.

</details>

## 🔧 앞으로의 할일

- 스토리지 도메인 테스트 코드을 작성할 예정입니다

  <br/>

## ➕ 이슈 링크

- #114

<br/>

## 커밋 리스트
- 초기 pr 커밋
   - [[feat]뉴스 테스트코드 작성](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/55e50096a35b0b8477fd6a8e4983bf6b434a29c8)
   - [[fix] 중복 코드 모듈화](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/87fa239441677fc996f297d917dea39a7117ce40)
   - [[fix] 중복 코드 수정 및 주석 작성](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/7b96adba501a8575bf9117b3444e4ca844621a43)
- 1차 수정
  -  [[fix] 뉴스 Mock 엔티티 패키지화 & 하드코딩 상수화](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/b972b61cfaa9fb0e55622a587a236a64f8ec337a)
  - [[fix] 검증 값 누락 수정](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/923d91a049c893a7fbeebfbc869727b5905ab7bc)
  - [[fix] 모듈 메서드 위치 변경](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/c2ad96d119d2de9788526ddf7dbacef33407a911)
  - [[fix] conflict 해결](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/46dc87b5942d0d9970dbd0405025785e43d77e11)
- 2차 수정
  - [[fix]뉴스 검증 로직 및 초기 값 수정](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/a7b6ffd1aff2f0e4f6ab46808c374322cf5d10f0)
[a7b6ffd](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/a7b6ffd1aff2f0e4f6ab46808c374322cf5d10f0)
  - [[fix] 뉴스 테스트 관련 상수화 클래스 네이밍 변경](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/12f34abf893dee882f90c87def039b4e71647041)
[12f34ab](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/12f34abf893dee882f90c87def039b4e71647041)
  - [[fix] 웹클라이언트목업세팅 util 화](https://github.com/100-hours-a-week/1-team-YouTIL-be/pull/121/commits/992d14b8aac5050c6d38c774592759b15f957bb6)
