### PR TITLE
[fix] 동시성 제어 / 전략 패턴 적용

### DIFF
--- a/src/main/java/com/youtil/Api/Interview/Handler/InterviewRequestHandler.java
+++ b/src/main/java/com/youtil/Api/Interview/Handler/InterviewRequestHandler.java
@@ -16,7 +16,7 @@ import static com.youtil.Common.Constants.InterviewServiceConstans.RESULT_KEY;
 import static com.youtil.Common.Constants.InterviewServiceConstans.RETRY_COUNT;
 import static com.youtil.Common.Constants.InterviewServiceConstans.STREAM_KEY;
 import static com.youtil.Common.Constants.InterviewServiceConstans.USER_ID_KEY;
-import com.youtil.Util.RedisSemaphoreManager;
+import com.youtil.Concurrency.RedisSemaphoreManager;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executors;

--- a/src/main/java/com/youtil/Api/Tils/Handler/TilRequestHandler.java
+++ b/src/main/java/com/youtil/Api/Tils/Handler/TilRequestHandler.java
@@ -25,7 +25,7 @@ import static com.youtil.Common.Constants.TilServiceConstants.RETRY_COUNT;
 import static com.youtil.Common.Constants.TilServiceConstants.STREAM_KEY;
 import static com.youtil.Common.Constants.TilServiceConstants.USER_ID_KEY;
 import com.youtil.Common.Enums.AiType;
-import com.youtil.Util.RedisSemaphoreManager;
+import com.youtil.Concurrency.RedisSemaphoreManager;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executors;

--- a/src/main/java/com/youtil/Concurrency/GpuTimeChecker.java
+++ b/src/main/java/com/youtil/Concurrency/GpuTimeChecker.java
@@ -1,4 +1,4 @@
-package com.youtil.Util;
+package com.youtil.Concurrency;
 
 import java.time.LocalTime;
 import java.time.ZoneId;

--- a/src/main/java/com/youtil/Concurrency/RedisSemaphoreManager.java
+++ b/src/main/java/com/youtil/Concurrency/RedisSemaphoreManager.java
@@ -1,9 +1,10 @@
-package com.youtil.Util;
+package com.youtil.Concurrency;
 
 
 import static com.youtil.Common.Constants.TilServiceConstants.SEMAPHORE_TTL;
 import com.youtil.Common.Enums.AiType;
-import com.youtil.Exception.CommonException.ResourceNotFoundException;
+import com.youtil.Concurrency.policy.SemaphorePolicy;
+import com.youtil.Concurrency.policy.SemaphorePolicySelector;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,31 +31,22 @@ public class RedisSemaphoreManager {
             StandardCharsets.UTF_8);
     private static final StringRedisSerializer STRING_SERIALIZER = new StringRedisSerializer();
     private static final String SHARED_SEMAPHORE_KEY = "semaphore:shared";
-    private static final int TIL_CPU_SEMAPHORE_COUNT = 1;
-    private static final int TIL_GPU_SEMAPHORE_COUNT = 2;
-    private static final int INTERVIEW_CPU_SEMAPHORE_COUNT = 1;
-    private static final int INTERVIEW_GPU_SEMAPHORE_COUNT = 3;
-    private static final int SHARED_CPU_SEMAPHORE_COUNT = 1;
-    private static final int SHARED_GPU_SEMAPHORE_COUNT = 5;
     private static final String SEMAPHORE_KEY_PREFIX = "semaphore:";
     private static final String SEMAPHORE_KEY_SUFFIX = ":fixed";
     private final StringRedisTemplate redisTemplate;
+    private final SemaphorePolicySelector semaphorePolicySelector;
 
     public boolean tryAcquireSemaphore(String requestId, String resourceType) {
-        String fixedKey = getFixedKey(resourceType);
+        AiType aiType = AiType.valueOf(resourceType);
+        SemaphorePolicy policy = semaphorePolicySelector.getSemaphorePolicy();
 
-        int fixedLimit = getFixedLimit(resourceType);
-        int sharedLimit = getSharedLimit();
+        boolean acquiredFixed = tryAcquire(getFixedKey(resourceType), policy.getFixedLimit(aiType),
+                requestId);
 
-        // 고정 자원이 가능한지 확인한다.
-        boolean acquiredFixed = tryAcquire(fixedKey, fixedLimit, requestId);
+        //전용자원이 없을 경우, 공유 자원에 접근한다.
+        return acquiredFixed || tryAcquire(SHARED_SEMAPHORE_KEY, policy.getSharedLimit(),
+                requestId);
 
-        if (acquiredFixed) {
-            return true;
-        }
-
-        // 공유 자원 사용이 가능한지 확인한다.
-        return tryAcquire(SHARED_SEMAPHORE_KEY, sharedLimit, requestId);
     }
 
 
@@ -72,24 +64,6 @@ public class RedisSemaphoreManager {
         });
 
         return result != null && result == 1;
-    }
-
-    private int getFixedLimit(String resourceType) {
-
-        boolean isGpuTime = GpuTimeChecker.isGpuTimeNow();
-
-        if (resourceType.equals(AiType.TIL.toString())) {
-            return isGpuTime ? TIL_GPU_SEMAPHORE_COUNT : TIL_CPU_SEMAPHORE_COUNT;
-        } else if (resourceType.equals(AiType.INTERVIEW.toString())) {
-            return isGpuTime ? INTERVIEW_GPU_SEMAPHORE_COUNT : INTERVIEW_CPU_SEMAPHORE_COUNT;
-        }
-        throw new ResourceNotFoundException();
-    }
-
-    private int getSharedLimit() {
-        return GpuTimeChecker.isGpuTimeNow()
-                ? SHARED_GPU_SEMAPHORE_COUNT
-                : SHARED_CPU_SEMAPHORE_COUNT;
     }
 
     public void releaseSemaphore(String requestId, String resourceType) {

--- a/src/main/java/com/youtil/Concurrency/policy/CpuTimeSemaphorePolicy.java
+++ b/src/main/java/com/youtil/Concurrency/policy/CpuTimeSemaphorePolicy.java
@@ -1,0 +1,25 @@
+package com.youtil.Concurrency.policy;
+
+import com.youtil.Common.Enums.AiType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CpuTimeSemaphorePolicy implements SemaphorePolicy {
+
+    private static final int TIL_CPU_SEMAPHORE_COUNT = 1;
+    private static final int INTERVIEW_CPU_SEMAPHORE_COUNT = 1;
+    private static final int SHARED_CPU_SEMAPHORE_COUNT = 1;
+
+    @Override
+    public int getFixedLimit(AiType aiType) {
+        return switch (aiType) {
+            case TIL -> TIL_CPU_SEMAPHORE_COUNT;
+            case INTERVIEW -> INTERVIEW_CPU_SEMAPHORE_COUNT;
+        };
+    }
+
+    @Override
+    public int getSharedLimit() {
+        return SHARED_CPU_SEMAPHORE_COUNT;
+    }
+}

--- a/src/main/java/com/youtil/Concurrency/policy/GpuTimeSemaphorePolicy.java
+++ b/src/main/java/com/youtil/Concurrency/policy/GpuTimeSemaphorePolicy.java
@@ -1,0 +1,25 @@
+package com.youtil.Concurrency.policy;
+
+import com.youtil.Common.Enums.AiType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GpuTimeSemaphorePolicy implements SemaphorePolicy {
+
+    private static final int TIL_GPU_SEMAPHORE_COUNT = 2;
+    private static final int INTERVIEW_GPU_SEMAPHORE_COUNT = 3;
+    private static final int SHARED_GPU_SEMAPHORE_COUNT = 5;
+
+    @Override
+    public int getFixedLimit(AiType aiType) {
+        return switch (aiType) {
+            case TIL -> TIL_GPU_SEMAPHORE_COUNT;
+            case INTERVIEW -> INTERVIEW_GPU_SEMAPHORE_COUNT;
+        };
+    }
+
+    @Override
+    public int getSharedLimit() {
+        return SHARED_GPU_SEMAPHORE_COUNT;
+    }
+}

--- a/src/main/java/com/youtil/Concurrency/policy/SemaphorePolicy.java
+++ b/src/main/java/com/youtil/Concurrency/policy/SemaphorePolicy.java
@@ -1,0 +1,10 @@
+package com.youtil.Concurrency.policy;
+
+import com.youtil.Common.Enums.AiType;
+
+public interface SemaphorePolicy {
+
+    int getFixedLimit(AiType aiType);
+
+    int getSharedLimit();
+}

--- a/src/main/java/com/youtil/Concurrency/policy/SemaphorePolicySelector.java
+++ b/src/main/java/com/youtil/Concurrency/policy/SemaphorePolicySelector.java
@@ -1,0 +1,17 @@
+package com.youtil.Concurrency.policy;
+
+import com.youtil.Concurrency.GpuTimeChecker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SemaphorePolicySelector {
+
+    private final GpuTimeSemaphorePolicy gpuTimeSemaphorePolicy;
+    private final CpuTimeSemaphorePolicy cpuTimeSemaphorePolicy;
+
+    public SemaphorePolicy getSemaphorePolicy() {
+        return GpuTimeChecker.isGpuTimeNow() ? gpuTimeSemaphorePolicy : cpuTimeSemaphorePolicy;
+    }
+}


### PR DESCRIPTION
- 제목 : fix(178): 동시성 제어 - 전략 패턴 적용

## 🔘Part

- [x] BE : Jun @jainefer 

  <br/>

## 🔎 작업 내용

- 기존 단순 고정 값 기반의 AI 동시성 제어 로직을 시간대 기반 전략 패턴으로 리팩토링했습니다. 
- 시간대( 15시 기준) 별로 GPU / CPU 서버 자원에 대해 동시 요청 수 제한을 유동적으로 설정할 수 있도록 개선했습니다.
- SemaphorePolicy 인터페이스를 정의하고, GpuTimeSemaphorePolicy , CpuTimeSemaphorePolicy 구현체를 통해 고정 및 공유 자원의 세마포어 제한 수를 분리했습니다.
- SemaphorePolicySelector를 통해 현재 시간이 GPU 시간인지 판단하고, 이에 따라 적절한 전략을 RedisSemaphoreManager에 주입하여, 세마포어 로직의 유연성을 확보했습니다.

  <br/>

## 🔧 앞으로의 과제

- 다른 작업 코드 도 보면서, 코드 단위로 개선할 점을 찾고, 이를 통해 적절한 디자인패턴을 적용하겠습니다.

  <br/>

## ➕ 이슈 링크

- #178 

<br/>
