### PR TITLE
일별 커밋 여부 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,12 @@ sourceSets {
         java {
             srcDir querydslDir
         }
+        resources {
+            srcDirs = [
+                    'src/main/resources',
+                    'shared-config'
+            ]
+        }
     }
 }
 

--- a/src/main/java/com/youtil/Api/Github/Controller/GithubCommitCalendarController.java
+++ b/src/main/java/com/youtil/Api/Github/Controller/GithubCommitCalendarController.java
@@ -1,0 +1,143 @@
+package com.youtil.Api.Github.Controller;
+
+import com.youtil.Api.Github.Dto.CommitCalendarResponseDTO.CommitCalendarResponse;
+import com.youtil.Api.Github.Service.GithubCommitCalendarService;
+import com.youtil.Common.ApiResponse;
+import com.youtil.Util.JwtUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+@RestController
+@RequestMapping("/api/v1/github")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "github", description = "깃허브 관련 API")
+public class GithubCommitCalendarController {
+
+    private final GithubCommitCalendarService githubCommitCalendarService;
+
+    @Operation(
+            summary = "커밋 존재 여부 달력 조회",
+            description = "지정된 기간 동안 커밋이 있는 날짜들을 조회합니다. Redis 캐싱을 활용하여 성능을 최적화합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "커밋 달력 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommitCalendarResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "유효하지 않은 파라미터"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 오류"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "GitHub API 호출 오류"
+            )
+    })
+    @GetMapping("/commits/calendar")
+    public ApiResponse<CommitCalendarResponse> getCommitCalendar(
+            @Parameter(name = "organizationId", description = "조직 ID (선택사항)", required = false)
+            @RequestParam(required = false) Long organizationId,
+
+            @Parameter(name = "repositoryId", description = "레포지토리 ID", required = true, example = "927579728")
+            @RequestParam Long repositoryId,
+
+            @Parameter(name = "branch", description = "브랜치명", required = true, example = "main")
+            @RequestParam String branch,
+
+            @Parameter(name = "startDate", description = "시작 날짜 (YYYY-MM-DD). 기본값: 3개월 전", required = false, example = "2024-03-20")
+            @RequestParam(required = false) String startDate,
+
+            @Parameter(name = "endDate", description = "종료 날짜 (YYYY-MM-DD). 기본값: 오늘", required = false, example = "2024-06-20")
+            @RequestParam(required = false) String endDate) {
+
+        log.info("커밋 달력 조회 요청: 조직={}, 레포={}, 브랜치={}, 시작일={}, 종료일={}",
+                organizationId, repositoryId, branch, startDate, endDate);
+
+        Long userId = JwtUtil.getAuthenticatedUserId();
+
+        try {
+            // 요청 검증
+            if (repositoryId == null) {
+                throw new IllegalArgumentException("레포지토리 ID는 필수입니다.");
+            }
+            if (branch == null || branch.trim().isEmpty()) {
+                throw new IllegalArgumentException("브랜치명은 필수입니다.");
+            }
+
+            // 날짜 파싱 및 기본값 설정
+            LocalDate start, end;
+
+            if (endDate != null) {
+                try {
+                    end = LocalDate.parse(endDate);
+                } catch (DateTimeParseException e) {
+                    throw new IllegalArgumentException("종료 날짜 형식이 올바르지 않습니다. YYYY-MM-DD 형식으로 입력해주세요.");
+                }
+            } else {
+                end = LocalDate.now();
+            }
+
+            if (startDate != null) {
+                try {
+                    start = LocalDate.parse(startDate);
+                } catch (DateTimeParseException e) {
+                    throw new IllegalArgumentException("시작 날짜 형식이 올바르지 않습니다. YYYY-MM-DD 형식으로 입력해주세요.");
+                }
+            } else {
+                start = end.minusMonths(3); // 기본값: 3개월 전
+            }
+
+            // 날짜 범위 검증
+            if (start.isAfter(end)) {
+                throw new IllegalArgumentException("시작 날짜는 종료 날짜보다 이전이어야 합니다.");
+            }
+
+            // 최대 조회 기간 제한 (1년)
+            if (start.isBefore(end.minusYears(1))) {
+                throw new IllegalArgumentException("조회 기간은 최대 1년까지 가능합니다.");
+            }
+
+            // 서비스 호출
+            CommitCalendarResponse result =
+                    githubCommitCalendarService.getCommitCalendar(userId, organizationId, repositoryId, branch, start, end);
+
+            log.info("커밋 달력 조회 성공: {}일 중 {}일에 커밋 존재",
+                    result.getPeriod().getTotalDays(), result.getPeriod().getCommitDays());
+
+            return new ApiResponse<>(
+                    "커밋 달력 조회가 완료되었습니다.",
+                    "GITHUB_COMMIT_CALENDAR_FETCHED",
+                    result);
+
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 요청 파라미터: {}", e.getMessage());
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        } catch (DateTimeParseException e) {
+            log.warn("날짜 파싱 오류: {}", e.getMessage());
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "날짜 형식이 올바르지 않습니다. YYYY-MM-DD 형식으로 입력해주세요.");
+        } catch (RuntimeException e) {
+            log.error("커밋 달력 조회 오류: {}", e.getMessage());
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "커밋 달력 조회 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/youtil/Api/Github/Converter/GitHubDtoConverter.java
+++ b/src/main/java/com/youtil/Api/Github/Converter/GitHubDtoConverter.java
@@ -2,12 +2,8 @@ package com.youtil.Api.Github.Converter;
 
 import com.youtil.Api.Github.Dto.CommitDetailRequestDTO;
 import com.youtil.Api.Github.Dto.CommitDetailResponseDTO;
-import com.youtil.Api.Github.Dto.CommitSummaryResponseDTO;
 import com.youtil.Api.Github.Dto.GithubResponseDTO;
-import com.youtil.Api.Github.Dto.CommitCalendarResponseDTO;
 
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +30,6 @@ public class GitHubDtoConverter {
                     .collect(Collectors.toList());
         }
 
-        // 다음 페이지 존재 여부 판단: 요청한 pageSize와 실제 받은 데이터 수가 같으면 다음 페이지가 있을 가능성
         boolean hasNext = organizations.size() == pageSize;
 
         return GithubResponseDTO.OrganizationResponseDTO.builder()
@@ -101,66 +96,6 @@ public class GitHubDtoConverter {
     }
 
     /**
-     * 기존 호환성을 위한 오버로드 메서드들 (페이지네이션 정보 없이 - 기본값 사용)
-     */
-    public static GithubResponseDTO.OrganizationResponseDTO toOrganizationResponse(
-            Map<String, Object>[] orgsResponse) {
-        int defaultSize = orgsResponse != null ? orgsResponse.length : 0;
-        return toOrganizationResponse(orgsResponse, 1, defaultSize);
-    }
-
-    public static GithubResponseDTO.RepositoryResponseDTO toRepositoryResponse(
-            Map<String, Object>[] reposResponse) {
-        int defaultSize = reposResponse != null ? reposResponse.length : 0;
-        return toRepositoryResponse(reposResponse, 1, defaultSize);
-    }
-
-    public static GithubResponseDTO.BranchResponseDTO toBranchResponse(
-            Map<String, Object>[] branchesResponse) {
-        int defaultSize = branchesResponse != null ? branchesResponse.length : 0;
-        return toBranchResponse(branchesResponse, 1, defaultSize);
-    }
-
-    /**
-     * GitHub API 커밋 응답을 CommitSummaryResponse로 변환
-     */
-    public static CommitSummaryResponseDTO.CommitSummaryResponse toCommitSummaryResponse(
-            Map<String, Object>[] commitsResponse, String username,String date,String repoName,String owner,
-            int currentPage, int pageSize) {
-
-        List<CommitSummaryResponseDTO.CommitSummary> commitSummaries = new ArrayList<>();
-
-        if (commitsResponse != null) {
-            commitSummaries = java.util.Arrays.stream(commitsResponse)
-                    .map(commit -> {
-                        String sha = commit.get("sha").toString();
-                        Map<String, Object> commitData = (Map<String, Object>) commit.get("commit");
-                        String message = commitData.get("message").toString();
-
-                        return CommitSummaryResponseDTO.CommitSummary.builder()
-                                .sha(sha)
-                                .commitMessage(message)
-                                .build();
-                    })
-                    .collect(Collectors.toList());
-        }
-
-        boolean hasNext = commitSummaries.size() == pageSize;
-
-        return CommitSummaryResponseDTO.CommitSummaryResponse.builder()
-                .username(username)
-                .date(date)
-                .repo(repoName)
-                .owner(owner)
-                .commits(commitSummaries)
-                .currentPage(currentPage)
-                .pageSize(pageSize)
-                .currentPageSize(commitSummaries.size())
-                .hasNext(hasNext)
-                .build();
-    }
-
-    /**
      * GitHub API 커밋 상세 응답을 CommitDetailResponse로 변환
      */
     public static CommitDetailResponseDTO.CommitDetailResponse toCommitDetailResponse(
@@ -175,26 +110,6 @@ public class GitHubDtoConverter {
                 .repo(repoName)
                 .files(fileDetails)
                 .build();
-    }
-
-    /**
-     * 커밋 API 응답에서 날짜 추출
-     */
-    public static String extractDateFromCommit(Map<String, Object> commitInfo) {
-        try {
-            Map<String, Object> commit = (Map<String, Object>) commitInfo.get("commit");
-            if (commit != null && commit.containsKey("committer")) {
-                Map<String, Object> committer = (Map<String, Object>) commit.get("committer");
-                if (committer != null && committer.containsKey("date")) {
-                    String dateStr = committer.get("date").toString();
-                    OffsetDateTime dateTime = OffsetDateTime.parse(dateStr);
-                    return dateTime.toLocalDate().toString();
-                }
-            }
-        } catch (Exception e) {
-            // 날짜 파싱 실패시 null 반환
-        }
-        return null;
     }
 
     /**
@@ -213,42 +128,5 @@ public class GitHubDtoConverter {
                         .message(commit.getMessage())
                         .build())
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * 커밋 달력 응답을 생성합니다.
-     */
-    public static CommitCalendarResponseDTO.CommitCalendarResponse toCommitCalendarResponse(
-            String username, String repo, String owner, String branch,
-            Map<String, Integer> calendar, String startDate, String endDate) {
-
-        CommitCalendarResponseDTO.PeriodInfo periodInfo = CommitCalendarResponseDTO.PeriodInfo.builder()
-                .startDate(startDate)
-                .endDate(endDate)
-                .totalDays(calculateDaysBetween(startDate, endDate))
-                .commitDays(calendar.size())
-                .build();
-
-        return CommitCalendarResponseDTO.CommitCalendarResponse.builder()
-                .username(username)
-                .repo(repo)
-                .owner(owner)
-                .branch(branch)
-                .calendar(calendar)
-                .period(periodInfo)
-                .build();
-    }
-
-    /**
-     * 두 날짜 사이의 일수를 계산합니다.
-     */
-    private static int calculateDaysBetween(String startDate, String endDate) {
-        try {
-            LocalDate start = LocalDate.parse(startDate);
-            LocalDate end = LocalDate.parse(endDate);
-            return (int) java.time.temporal.ChronoUnit.DAYS.between(start, end) + 1;
-        } catch (Exception e) {
-            return 0;
-        }
     }
 }

--- a/src/main/java/com/youtil/Api/Github/Converter/GitHubDtoConverter.java
+++ b/src/main/java/com/youtil/Api/Github/Converter/GitHubDtoConverter.java
@@ -4,7 +4,9 @@ import com.youtil.Api.Github.Dto.CommitDetailRequestDTO;
 import com.youtil.Api.Github.Dto.CommitDetailResponseDTO;
 import com.youtil.Api.Github.Dto.CommitSummaryResponseDTO;
 import com.youtil.Api.Github.Dto.GithubResponseDTO;
+import com.youtil.Api.Github.Dto.CommitCalendarResponseDTO;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -211,5 +213,42 @@ public class GitHubDtoConverter {
                         .message(commit.getMessage())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 커밋 달력 응답을 생성합니다.
+     */
+    public static CommitCalendarResponseDTO.CommitCalendarResponse toCommitCalendarResponse(
+            String username, String repo, String owner, String branch,
+            Map<String, Integer> calendar, String startDate, String endDate) {
+
+        CommitCalendarResponseDTO.PeriodInfo periodInfo = CommitCalendarResponseDTO.PeriodInfo.builder()
+                .startDate(startDate)
+                .endDate(endDate)
+                .totalDays(calculateDaysBetween(startDate, endDate))
+                .commitDays(calendar.size())
+                .build();
+
+        return CommitCalendarResponseDTO.CommitCalendarResponse.builder()
+                .username(username)
+                .repo(repo)
+                .owner(owner)
+                .branch(branch)
+                .calendar(calendar)
+                .period(periodInfo)
+                .build();
+    }
+
+    /**
+     * 두 날짜 사이의 일수를 계산합니다.
+     */
+    private static int calculateDaysBetween(String startDate, String endDate) {
+        try {
+            LocalDate start = LocalDate.parse(startDate);
+            LocalDate end = LocalDate.parse(endDate);
+            return (int) java.time.temporal.ChronoUnit.DAYS.between(start, end) + 1;
+        } catch (Exception e) {
+            return 0;
+        }
     }
 }

--- a/src/main/java/com/youtil/Api/Github/Dto/CommitCalendarResponseDTO.java
+++ b/src/main/java/com/youtil/Api/Github/Dto/CommitCalendarResponseDTO.java
@@ -1,0 +1,54 @@
+package com.youtil.Api.Github.Dto;
+
+import io.netty.channel.ChannelHandler;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+public class CommitCalendarResponseDTO {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "커밋 존재 여부 달력 응답 DTO")
+    public static class CommitCalendarResponse {
+        @Schema(description = "사용자명", example = "user_name")
+        private String username;
+
+        @Schema(description = "레포지토리명", example = "backend")
+        private String repo;
+
+        @Schema(description = "레포지토리 소유자", example = "youtil-org")
+        private String owner;
+
+        @Schema(description = "브랜치명", example = "main")
+        private String branch;
+
+        @Schema(description = "커밋이 있는 날짜 맵 (날짜: 1)",
+                example = "{'2024-06-01': 1, '2024-06-03': 1, '2024-06-10': 1}")
+        private Map<String, Integer> calendar;
+
+        @Schema(description = "조회 기간 정보")
+        private PeriodInfo period;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "커밋 존재 여부 달력 응답 DTO")
+    public static class PeriodInfo {
+        @Schema(description = "시작날짜", example = "2025-01-01")
+        private String startDate;
+
+        @Schema(description = "종료 날짜", example = "2025-03-31")
+        private String endDate;
+
+        @Schema(description = "총 조회 일수", example = "93")
+        private int totalDays;
+
+        @Schema(description = "커밋이 있는 일수", example = "32")
+        private int commitDays;
+    }
+}

--- a/src/main/java/com/youtil/Api/Github/Dto/CommitCalendarResponseDTO.java
+++ b/src/main/java/com/youtil/Api/Github/Dto/CommitCalendarResponseDTO.java
@@ -1,6 +1,5 @@
 package com.youtil.Api.Github.Dto;
 
-import io.netty.channel.ChannelHandler;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/youtil/Api/Github/Service/GithubCommitCalendarService.java
+++ b/src/main/java/com/youtil/Api/Github/Service/GithubCommitCalendarService.java
@@ -1,15 +1,13 @@
 package com.youtil.Api.Github.Service;
 
-import com.youtil.Api.Github.Dto.CommitCalendarResponseDTO;
 import com.youtil.Api.Github.Dto.CommitCalendarResponseDTO.CommitCalendarResponse;
 import com.youtil.Api.Github.Dto.CommitCalendarResponseDTO.PeriodInfo;
 import com.youtil.Api.Github.Util.GitHubApiUtils;
-import com.youtil.Common.Enums.TilMessageCode;
 import com.youtil.Model.User;
 import com.youtil.Util.EntityValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -21,7 +19,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -31,20 +29,20 @@ public class GithubCommitCalendarService {
     private final WebClient webClient;
     private final EntityValidator entityValidator;
     private final GitHubApiUtils gitHubApiUtils;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate redisTemplate;
 
-    private static final String COMMIT_EXISTS_KEY_PATTERN = "commit_exists:user:%d:repo:%d:branch:%s:date:%s";
+    private static final String COMMIT_CALENDAR_HASH_PATTERN = "commit_calendar:user:%d:repo:%d:branch:%s:%s";
     private static final Duration CACHE_TTL = Duration.ofDays(30); // 30일 TTL
 
     /**
-     * 3개월간의 커밋 존재 여부 달력 데이터를 조회합니다.
+     * Hash 구조를 사용한 최적화된 커밋 달력 조회 (StringRedisTemplate 버전)
      */
     public CommitCalendarResponse getCommitCalendar(
             Long userId, Long organizationId, Long repositoryId, String branch,
             LocalDate startDate, LocalDate endDate) {
 
         long startTime = System.currentTimeMillis();
-        log.info("커밋 달력 조회 시작: 사용자={}, 레포={}, 브랜치={}, 기간={} ~ {}",
+        log.info("StringRedisTemplate Hash 구조 커밋 달력 조회 시작: 사용자={}, 레포={}, 브랜치={}, 기간={} ~ {}",
                 userId, repositoryId, branch, startDate, endDate);
 
         // 사용자 조회 및 토큰 검증
@@ -60,123 +58,166 @@ public class GithubCommitCalendarService {
 
         log.info("레포지토리 정보: 소유자={}, 레포명={}", owner, repoName);
 
-        // 1단계: 날짜 범위 생성
-        List<String> dateList = generateDateRange(startDate, endDate);
-        log.info("조회할 날짜 수: {}일", dateList.size());
+        // 1단계: 날짜를 월별로 그룹화
+        Map<String, List<String>> monthlyDates = groupDatesByMonth(startDate, endDate);
+        log.info("조회 대상 월: {}, 총 날짜 수: {}", monthlyDates.keySet(),
+                monthlyDates.values().stream().mapToInt(List::size).sum());
 
-        // 2단계: Redis 배치 조회
-        List<String> redisKeys = generateRedisKeys(userId, repositoryId, branch, dateList);
-        List<Object> cachedValues = redisTemplate.opsForValue().multiGet(redisKeys);
-
-        // 3단계: 캐시 분석 및 미스된 날짜 수집
+        // 2단계: Redis Hash에서 월별 배치 조회 (StringRedisTemplate)
         Map<String, Integer> cachedCommits = new HashMap<>();
-        List<String> missedDates = new ArrayList<>();
+        Set<String> missedDates = new HashSet<>();
 
-        analyzeCacheResults(dateList, cachedValues, cachedCommits, missedDates);
+        batchFetchFromRedisHash(userId, repositoryId, branch, monthlyDates, cachedCommits, missedDates);
 
         log.info("캐시 분석 결과: 히트={}, 미스={}", cachedCommits.size(), missedDates.size());
 
-        // 4단계: 캐시 미스된 날짜들에 대해 GitHub API 호출
+        // 3단계: 캐시 미스된 날짜들에 대해 GitHub API 호출
         if (!missedDates.isEmpty()) {
-            checkMissedDatesFromGitHub(missedDates, userId, repositoryId, branch, owner, repoName,
+            checkMissedDatesAndSaveToHash(missedDates, userId, repositoryId, branch, owner, repoName,
                     token, username, cachedCommits);
         }
 
+        // 4단계: 날짜 내림차순으로 정렬된 calendar 생성
+        Map<String, Integer> sortedCalendar = cachedCommits.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByKey().reversed())
+                .collect(LinkedHashMap::new,
+                        (map, entry) -> map.put(entry.getKey(), entry.getValue()),
+                        LinkedHashMap::putAll);
+
         // 5단계: 응답 생성
+        int totalDays = (int) startDate.datesUntil(endDate.plusDays(1)).count();
         PeriodInfo periodInfo = PeriodInfo.builder()
                 .startDate(startDate.toString())
                 .endDate(endDate.toString())
-                .totalDays(dateList.size())
-                .commitDays(cachedCommits.size())
+                .totalDays(totalDays)
+                .commitDays(sortedCalendar.size())
                 .build();
 
         long duration = System.currentTimeMillis() - startTime;
-        log.info("커밋 달력 조회 완료: {}일 중 {}일에 커밋 존재, 소요시간={}ms",
-                dateList.size(), cachedCommits.size(), duration);
+        log.info("StringRedisTemplate Hash 구조 커밋 달력 조회 완료: {}일 중 {}일에 커밋 존재, 소요시간={}ms (내림차순 정렬 적용)",
+                totalDays, sortedCalendar.size(), duration);
 
         return CommitCalendarResponse.builder()
                 .username(username)
                 .repo(repoName)
                 .owner(owner)
                 .branch(branch)
-                .calendar(cachedCommits)
+                .calendar(sortedCalendar)
                 .period(periodInfo)
                 .build();
     }
 
     /**
-     * 날짜 범위 생성
+     * 날짜를 년월별로 그룹화
      */
-    private List<String> generateDateRange(LocalDate startDate, LocalDate endDate) {
-        List<String> dateList = new ArrayList<>();
-        LocalDate currentDate = startDate;
+    private Map<String, List<String>> groupDatesByMonth(LocalDate startDate, LocalDate endDate) {
+        Map<String, List<String>> monthlyDates = new LinkedHashMap<>();
 
+        LocalDate currentDate = startDate;
         while (!currentDate.isAfter(endDate)) {
-            dateList.add(currentDate.toString());
+            String yearMonth = currentDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+            monthlyDates.computeIfAbsent(yearMonth, k -> new ArrayList<>()).add(currentDate.toString());
             currentDate = currentDate.plusDays(1);
         }
 
-        return dateList;
+        log.debug("월별 그룹화 완료: {} 개월", monthlyDates.size());
+        return monthlyDates;
     }
 
     /**
-     * Redis 키 생성
+     * Redis Hash에서 월별 배치 조회 (StringRedisTemplate 버전)
      */
-    private List<String> generateRedisKeys(Long userId, Long repositoryId, String branch, List<String> dateList) {
-        return dateList.stream()
-                .map(date -> String.format(COMMIT_EXISTS_KEY_PATTERN, userId, repositoryId, branch, date))
-                .collect(Collectors.toList());
-    }
+    private void batchFetchFromRedisHash(Long userId, Long repositoryId, String branch,
+                                         Map<String, List<String>> monthlyDates,
+                                         Map<String, Integer> cachedCommits, Set<String> missedDates) {
 
-    /**
-     * 캐시 결과 분석
-     */
-    private void analyzeCacheResults(List<String> dateList, List<Object> cachedValues,
-                                     Map<String, Integer> cachedCommits, List<String> missedDates) {
-        for (int i = 0; i < dateList.size(); i++) {
-            String date = dateList.get(i);
-            Object cachedValue = cachedValues.get(i);
+        for (Map.Entry<String, List<String>> entry : monthlyDates.entrySet()) {
+            String yearMonth = entry.getKey();
+            List<String> datesInMonth = entry.getValue();
 
-            if (cachedValue != null) {
-                // 캐시 히트: 이미 조회한 날짜
-                int value = Integer.parseInt(cachedValue.toString());
-                if (value == 1) {
-                    cachedCommits.put(date, 1); // 커밋 있는 날짜만 응답에 포함
+            String hashKey = String.format(COMMIT_CALENDAR_HASH_PATTERN, userId, repositoryId, branch, yearMonth);
+
+            // StringRedisTemplate Hash에서 해당 월의 모든 필드(날짜) 조회
+            // 모든 값이 String으로 반환됨
+            Map<Object, Object> monthData = redisTemplate.opsForHash().entries(hashKey);
+
+            for (String date : datesInMonth) {
+                Object cachedValue = monthData.get(date);
+
+                if (cachedValue != null) {
+                    try {
+                        // String 값을 int로 파싱
+                        String valueStr = cachedValue.toString();
+                        int value = Integer.parseInt(valueStr);
+                        if (value == 1) {
+                            cachedCommits.put(date, 1); // 커밋 있는 날짜만 응답에 포함
+                        }
+                        log.debug("StringRedisTemplate Hash 캐시 히트: {} -> {}", date, value);
+                    } catch (NumberFormatException e) {
+                        log.warn("StringRedisTemplate Hash 캐시 값 파싱 오류: date={}, value={}", date, cachedValue);
+                        missedDates.add(date);
+                    }
+                } else {
+                    missedDates.add(date);
+                    log.debug("StringRedisTemplate Hash 캐시 미스: {}", date);
                 }
-                // value == 0이면 커밋 없는 날짜 (응답에서 제외, API 호출도 안함)
-            } else {
-                // 캐시 미스: 아직 조회 안한 날짜
-                missedDates.add(date);
             }
+
+            log.debug("월별 StringRedisTemplate Hash 조회 완료: {} - 캐시된 날짜: {}/{}",
+                    yearMonth, monthData.size(), datesInMonth.size());
         }
     }
 
     /**
-     * 캐시 미스된 날짜들에 대해 GitHub API 호출
+     * 미스된 날짜들을 GitHub에서 조회하고 Hash에 배치 저장 (StringRedisTemplate 버전)
      */
-    private void checkMissedDatesFromGitHub(List<String> missedDates, Long userId, Long repositoryId,
-                                            String branch, String owner, String repoName, String token,
-                                            String username, Map<String, Integer> cachedCommits) {
+    private void checkMissedDatesAndSaveToHash(Set<String> missedDates, Long userId, Long repositoryId,
+                                               String branch, String owner, String repoName, String token,
+                                               String username, Map<String, Integer> cachedCommits) {
+
         log.info("GitHub API 호출 시작: {}개 날짜 확인", missedDates.size());
+
+        Map<String, Map<String, String>> monthlyUpdates = new HashMap<>();
 
         for (String date : missedDates) {
             try {
                 boolean hasCommits = checkCommitsForDate(owner, repoName, branch, date, token, username);
 
-                // 조회 결과를 무조건 저장 (0 또는 1)
+                String yearMonth = date.substring(0, 7);
+                monthlyUpdates.computeIfAbsent(yearMonth, k -> new HashMap<>())
+                        .put(date, hasCommits ? "1" : "0");
+
                 if (hasCommits) {
-                    saveToRedis(userId, repositoryId, branch, date, 1);
                     cachedCommits.put(date, 1); // 응답에 포함
                     log.debug("커밋 발견: {}", date);
                 } else {
-                    saveToRedis(userId, repositoryId, branch, date, 0);
-                    // cachedCommits에는 추가하지 않음 (응답에서 제외)
                     log.debug("커밋 없음: {}", date);
                 }
+
             } catch (Exception e) {
                 log.warn("날짜 {} 커밋 확인 실패: {}", date, e.getMessage());
-                // 오류 발생시 해당 날짜는 캐싱하지 않음 (다음에 다시 시도)
             }
+        }
+
+        for (Map.Entry<String, Map<String, String>> entry : monthlyUpdates.entrySet()) {
+            String yearMonth = entry.getKey();
+            Map<String, String> updates = entry.getValue();
+
+            String hashKey = String.format(COMMIT_CALENDAR_HASH_PATTERN, userId, repositoryId, branch, yearMonth);
+
+            // 날짜 내림차순으로 정렬하여 저장
+            Map<String, String> sortedUpdates = updates.entrySet().stream()
+                    .sorted(Map.Entry.<String, String>comparingByKey().reversed()) // 날짜 내림차순 정렬
+                    .collect(LinkedHashMap::new,
+                            (map, updateEntry) -> map.put(updateEntry.getKey(), updateEntry.getValue()),
+                            LinkedHashMap::putAll);
+
+            // StringRedisTemplate Hash에 정렬된 순서로 배치 저장
+            redisTemplate.opsForHash().putAll(hashKey, sortedUpdates);
+            redisTemplate.expire(hashKey, CACHE_TTL.getSeconds(), TimeUnit.SECONDS);
+
+            log.info("StringRedisTemplate Redis Hash 배치 저장 완료 (내림차순 정렬): key={}, 업데이트된 날짜 수={}, TTL={}일",
+                    hashKey, sortedUpdates.size(), CACHE_TTL.toDays());
         }
     }
 
@@ -198,6 +239,8 @@ public class GithubCommitCalendarService {
                     "https://api.github.com/repos/%s/%s/commits?sha=%s&since=%s&until=%s&author=%s&per_page=1",
                     owner, repo, branch, sinceIso, untilIso, authorUsername);
 
+            log.debug("GitHub API 호출: {}", commitsUrl);
+
             Map<String, Object>[] commits = webClient.get()
                     .uri(commitsUrl)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
@@ -205,7 +248,10 @@ public class GithubCommitCalendarService {
                     .bodyToMono(Map[].class)
                     .block();
 
-            return commits != null && commits.length > 0;
+            boolean hasCommits = commits != null && commits.length > 0;
+            log.debug("날짜 {} 커밋 확인 결과: {}", date, hasCommits);
+
+            return hasCommits;
 
         } catch (WebClientResponseException e) {
             if (e.getStatusCode().value() == 404) {
@@ -218,36 +264,5 @@ public class GithubCommitCalendarService {
             log.error("날짜 {} 커밋 확인 중 오류: {}", date, e.getMessage());
             throw new RuntimeException("커밋 확인 중 오류가 발생했습니다: " + e.getMessage());
         }
-    }
-
-    /**
-     * Redis에 커밋 존재 여부 저장
-     */
-    private void saveToRedis(Long userId, Long repositoryId, String branch, String date, int value) {
-        String key = String.format(COMMIT_EXISTS_KEY_PATTERN, userId, repositoryId, branch, date);
-        redisTemplate.opsForValue().set(key, value, CACHE_TTL);
-        log.info("Redis 저장 완료: key=[{}], value=[{}], TTL=[{}일]", key, value, CACHE_TTL.toDays());
-    }
-
-    /**
-     * Redis 키 확인용 디버그 메서드 (개발용)
-     */
-    public void debugRedisKeys(Long userId, Long repositoryId, String branch) {
-        String pattern = String.format("commit_exists:user:%d:repo:%d:branch:%s:*", userId, repositoryId, branch);
-        Set<String> keys = redisTemplate.keys(pattern);
-
-        log.info("=== Redis 키 디버그 정보 ===");
-        log.info("검색 패턴: {}", pattern);
-        log.info("찾은 키 개수: {}", keys != null ? keys.size() : 0);
-
-        if (keys != null && !keys.isEmpty()) {
-            keys.forEach(key -> {
-                Object value = redisTemplate.opsForValue().get(key);
-                log.info("키: {} -> 값: {}", key, value);
-            });
-        } else {
-            log.info("해당 패턴의 키가 존재하지 않습니다.");
-        }
-        log.info("========================");
     }
 }

--- a/src/main/java/com/youtil/Api/Github/Service/GithubCommitCalendarService.java
+++ b/src/main/java/com/youtil/Api/Github/Service/GithubCommitCalendarService.java
@@ -1,0 +1,253 @@
+package com.youtil.Api.Github.Service;
+
+import com.youtil.Api.Github.Dto.CommitCalendarResponseDTO;
+import com.youtil.Api.Github.Dto.CommitCalendarResponseDTO.CommitCalendarResponse;
+import com.youtil.Api.Github.Dto.CommitCalendarResponseDTO.PeriodInfo;
+import com.youtil.Api.Github.Util.GitHubApiUtils;
+import com.youtil.Common.Enums.TilMessageCode;
+import com.youtil.Model.User;
+import com.youtil.Util.EntityValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GithubCommitCalendarService {
+
+    private final WebClient webClient;
+    private final EntityValidator entityValidator;
+    private final GitHubApiUtils gitHubApiUtils;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String COMMIT_EXISTS_KEY_PATTERN = "commit_exists:user:%d:repo:%d:branch:%s:date:%s";
+    private static final Duration CACHE_TTL = Duration.ofDays(30); // 30일 TTL
+
+    /**
+     * 3개월간의 커밋 존재 여부 달력 데이터를 조회합니다.
+     */
+    public CommitCalendarResponse getCommitCalendar(
+            Long userId, Long organizationId, Long repositoryId, String branch,
+            LocalDate startDate, LocalDate endDate) {
+
+        long startTime = System.currentTimeMillis();
+        log.info("커밋 달력 조회 시작: 사용자={}, 레포={}, 브랜치={}, 기간={} ~ {}",
+                userId, repositoryId, branch, startDate, endDate);
+
+        // 사용자 조회 및 토큰 검증
+        User user = entityValidator.getValidUserOrThrow(userId);
+        gitHubApiUtils.validateToken(user);
+        String token = gitHubApiUtils.decryptToken(user.getGithubToken());
+
+        // 레포지토리 정보 조회
+        Map<String, Object> repoInfo = gitHubApiUtils.getRepositoryById(repositoryId, token);
+        String repoName = repoInfo.get("name").toString();
+        String owner = ((Map<String, Object>) repoInfo.get("owner")).get("login").toString();
+        String username = gitHubApiUtils.getUsernameFromToken(token);
+
+        log.info("레포지토리 정보: 소유자={}, 레포명={}", owner, repoName);
+
+        // 1단계: 날짜 범위 생성
+        List<String> dateList = generateDateRange(startDate, endDate);
+        log.info("조회할 날짜 수: {}일", dateList.size());
+
+        // 2단계: Redis 배치 조회
+        List<String> redisKeys = generateRedisKeys(userId, repositoryId, branch, dateList);
+        List<Object> cachedValues = redisTemplate.opsForValue().multiGet(redisKeys);
+
+        // 3단계: 캐시 분석 및 미스된 날짜 수집
+        Map<String, Integer> cachedCommits = new HashMap<>();
+        List<String> missedDates = new ArrayList<>();
+
+        analyzeCacheResults(dateList, cachedValues, cachedCommits, missedDates);
+
+        log.info("캐시 분석 결과: 히트={}, 미스={}", cachedCommits.size(), missedDates.size());
+
+        // 4단계: 캐시 미스된 날짜들에 대해 GitHub API 호출
+        if (!missedDates.isEmpty()) {
+            checkMissedDatesFromGitHub(missedDates, userId, repositoryId, branch, owner, repoName,
+                    token, username, cachedCommits);
+        }
+
+        // 5단계: 응답 생성
+        PeriodInfo periodInfo = PeriodInfo.builder()
+                .startDate(startDate.toString())
+                .endDate(endDate.toString())
+                .totalDays(dateList.size())
+                .commitDays(cachedCommits.size())
+                .build();
+
+        long duration = System.currentTimeMillis() - startTime;
+        log.info("커밋 달력 조회 완료: {}일 중 {}일에 커밋 존재, 소요시간={}ms",
+                dateList.size(), cachedCommits.size(), duration);
+
+        return CommitCalendarResponse.builder()
+                .username(username)
+                .repo(repoName)
+                .owner(owner)
+                .branch(branch)
+                .calendar(cachedCommits)
+                .period(periodInfo)
+                .build();
+    }
+
+    /**
+     * 날짜 범위 생성
+     */
+    private List<String> generateDateRange(LocalDate startDate, LocalDate endDate) {
+        List<String> dateList = new ArrayList<>();
+        LocalDate currentDate = startDate;
+
+        while (!currentDate.isAfter(endDate)) {
+            dateList.add(currentDate.toString());
+            currentDate = currentDate.plusDays(1);
+        }
+
+        return dateList;
+    }
+
+    /**
+     * Redis 키 생성
+     */
+    private List<String> generateRedisKeys(Long userId, Long repositoryId, String branch, List<String> dateList) {
+        return dateList.stream()
+                .map(date -> String.format(COMMIT_EXISTS_KEY_PATTERN, userId, repositoryId, branch, date))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 캐시 결과 분석
+     */
+    private void analyzeCacheResults(List<String> dateList, List<Object> cachedValues,
+                                     Map<String, Integer> cachedCommits, List<String> missedDates) {
+        for (int i = 0; i < dateList.size(); i++) {
+            String date = dateList.get(i);
+            Object cachedValue = cachedValues.get(i);
+
+            if (cachedValue != null) {
+                // 캐시 히트: 이미 조회한 날짜
+                int value = Integer.parseInt(cachedValue.toString());
+                if (value == 1) {
+                    cachedCommits.put(date, 1); // 커밋 있는 날짜만 응답에 포함
+                }
+                // value == 0이면 커밋 없는 날짜 (응답에서 제외, API 호출도 안함)
+            } else {
+                // 캐시 미스: 아직 조회 안한 날짜
+                missedDates.add(date);
+            }
+        }
+    }
+
+    /**
+     * 캐시 미스된 날짜들에 대해 GitHub API 호출
+     */
+    private void checkMissedDatesFromGitHub(List<String> missedDates, Long userId, Long repositoryId,
+                                            String branch, String owner, String repoName, String token,
+                                            String username, Map<String, Integer> cachedCommits) {
+        log.info("GitHub API 호출 시작: {}개 날짜 확인", missedDates.size());
+
+        for (String date : missedDates) {
+            try {
+                boolean hasCommits = checkCommitsForDate(owner, repoName, branch, date, token, username);
+
+                // 조회 결과를 무조건 저장 (0 또는 1)
+                if (hasCommits) {
+                    saveToRedis(userId, repositoryId, branch, date, 1);
+                    cachedCommits.put(date, 1); // 응답에 포함
+                    log.debug("커밋 발견: {}", date);
+                } else {
+                    saveToRedis(userId, repositoryId, branch, date, 0);
+                    // cachedCommits에는 추가하지 않음 (응답에서 제외)
+                    log.debug("커밋 없음: {}", date);
+                }
+            } catch (Exception e) {
+                log.warn("날짜 {} 커밋 확인 실패: {}", date, e.getMessage());
+                // 오류 발생시 해당 날짜는 캐싱하지 않음 (다음에 다시 시도)
+            }
+        }
+    }
+
+    /**
+     * 특정 날짜에 커밋이 있는지 확인
+     */
+    private boolean checkCommitsForDate(String owner, String repo, String branch, String date,
+                                        String token, String authorUsername) {
+        try {
+            LocalDate targetDate = LocalDate.parse(date);
+            LocalDateTime startDateTime = targetDate.atStartOfDay();
+            LocalDateTime endDateTime = targetDate.plusDays(1).atStartOfDay();
+
+            String sinceIso = startDateTime.atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+            String untilIso = endDateTime.atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+
+            // GitHub API 호출 (첫 번째 커밋만 확인하면 되므로 per_page=1)
+            String commitsUrl = String.format(
+                    "https://api.github.com/repos/%s/%s/commits?sha=%s&since=%s&until=%s&author=%s&per_page=1",
+                    owner, repo, branch, sinceIso, untilIso, authorUsername);
+
+            Map<String, Object>[] commits = webClient.get()
+                    .uri(commitsUrl)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                    .retrieve()
+                    .bodyToMono(Map[].class)
+                    .block();
+
+            return commits != null && commits.length > 0;
+
+        } catch (WebClientResponseException e) {
+            if (e.getStatusCode().value() == 404) {
+                // 브랜치나 레포지토리를 찾을 수 없는 경우
+                log.warn("리소스를 찾을 수 없음: {}", e.getMessage());
+                return false;
+            }
+            throw new RuntimeException("GitHub API 호출 실패: " + e.getMessage());
+        } catch (Exception e) {
+            log.error("날짜 {} 커밋 확인 중 오류: {}", date, e.getMessage());
+            throw new RuntimeException("커밋 확인 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Redis에 커밋 존재 여부 저장
+     */
+    private void saveToRedis(Long userId, Long repositoryId, String branch, String date, int value) {
+        String key = String.format(COMMIT_EXISTS_KEY_PATTERN, userId, repositoryId, branch, date);
+        redisTemplate.opsForValue().set(key, value, CACHE_TTL);
+        log.info("Redis 저장 완료: key=[{}], value=[{}], TTL=[{}일]", key, value, CACHE_TTL.toDays());
+    }
+
+    /**
+     * Redis 키 확인용 디버그 메서드 (개발용)
+     */
+    public void debugRedisKeys(Long userId, Long repositoryId, String branch) {
+        String pattern = String.format("commit_exists:user:%d:repo:%d:branch:%s:*", userId, repositoryId, branch);
+        Set<String> keys = redisTemplate.keys(pattern);
+
+        log.info("=== Redis 키 디버그 정보 ===");
+        log.info("검색 패턴: {}", pattern);
+        log.info("찾은 키 개수: {}", keys != null ? keys.size() : 0);
+
+        if (keys != null && !keys.isEmpty()) {
+            keys.forEach(key -> {
+                Object value = redisTemplate.opsForValue().get(key);
+                log.info("키: {} -> 값: {}", key, value);
+            });
+        } else {
+            log.info("해당 패턴의 키가 존재하지 않습니다.");
+        }
+        log.info("========================");
+    }
+}

--- a/src/main/java/com/youtil/Config/GcpStorageConfig.java
+++ b/src/main/java/com/youtil/Config/GcpStorageConfig.java
@@ -16,15 +16,10 @@ public class GcpStorageConfig {
     @Value("${spring.cloud.project-id}")
     String projectId;
 
-    @Value("${spring.profiles.active:dev}")
-    private String activeProfile;
-
     @Bean
     public Storage storage() throws IOException {
-        // 환경별 JSON 파일 경로 설정
-        String jsonPath = "youtil-cloud-storage.json";
+        String jsonPath = "backend/youtil-cloud-storage.json";
 
-//        jsonPath = "shared-config/backend/youtil-cloud-storage.json";
         ClassPathResource resource = new ClassPathResource(jsonPath);
         try (InputStream credentialsStream = resource.getInputStream()) {
             GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsStream);
@@ -36,5 +31,4 @@ public class GcpStorageConfig {
                     .getService();
         }
     }
-
 }


### PR DESCRIPTION
- 제목 : feat(80): 일별 커밋 기록 조회

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 유저가 조직/레포/브랜치를 선택한 이후, 해당 브랜치 내에 자신의 커밋이 있는 날짜를 조회
- 깃허브 api 상으로 최대 1년까지 조회가 가능하며, 한번에 1년치를 조회한다면 한번에 2분이 소요된다. 
  그러므로 3개월치로 나누어 조회하고자 한다. 

  <br/>

## 🔧 앞으로의 과제

  <br/>

## ➕ 이슈 링크

- #80 

<br/>
