### PR TITLE
커뮤니티 도메인 테스트 코드

### DIFF
--- a/src/test/java/com/youtil/Api/Community/Service/CommunityServiceTest.java
+++ b/src/test/java/com/youtil/Api/Community/Service/CommunityServiceTest.java
@@ -8,9 +8,8 @@ import com.youtil.Model.User;
 import com.youtil.Repository.TilRecommendRepository;
 import com.youtil.Repository.TilRepository;
 import com.youtil.Repository.UserRepository;
-import com.youtil.Util.EntityValidator;
-import com.youtil.constant.CommunityTestConstant;
 import com.youtil.Mock.CommunityMockBuilder;
+import com.youtil.Constants.CommunityServiceConstant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -52,9 +51,6 @@ class CommunityServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private EntityValidator entityValidator;
-
-    @Mock
     private StringRedisTemplate redisTemplate;
 
     @Mock
@@ -72,9 +68,6 @@ class CommunityServiceTest {
         testUser = CommunityMockBuilder.createUser();
         testTil = CommunityMockBuilder.createPublicTil();
         testRecommend = CommunityMockBuilder.createTilRecommend();
-
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
     }
 
     @Nested
@@ -82,15 +75,15 @@ class CommunityServiceTest {
     class GetCommunityTilsTest {
 
         @Test
-        @DisplayName("성공: 유효한 카테고리로 요청 시 해당 카테고리 TIL 목록 반환")
+        @DisplayName("유효한 카테고리로 요청 시 해당 카테고리 TIL 목록 반환")
         void getCommunityTils_WithValidCategory_Success() {
             // given
             CommunityRequestDTO.CommunityListRequest request = CommunityMockBuilder.createCommunityListRequest();
             List<Til> tilList = CommunityMockBuilder.createTilList(2);
-            Pageable pageable = PageRequest.of(CommunityTestConstant.DEFAULT_PAGE, CommunityTestConstant.DEFAULT_SIZE);
+            Pageable pageable = PageRequest.of(CommunityServiceConstant.DEFAULT_PAGE, CommunityServiceConstant.DEFAULT_SIZE);
 
             given(tilRepository.findRecentPublicTilsByCategory(
-                    eq(CommunityTestConstant.CATEGORY_FULLSTACK.toUpperCase()),
+                    eq(CommunityServiceConstant.CATEGORY_FULLSTACK.toUpperCase()),
                     eq(pageable)
             )).willReturn(tilList);
 
@@ -100,22 +93,22 @@ class CommunityServiceTest {
             // then
             assertThat(response).isNotNull();
             assertThat(response.getTils()).hasSize(2);
-            assertThat(response.getTils().get(0).getCategory()).isEqualTo(CommunityTestConstant.TIL_CATEGORY);
+            assertThat(response.getTils().get(0).getCategory()).isEqualTo(CommunityServiceConstant.TIL_CATEGORY);
             verify(tilRepository).findRecentPublicTilsByCategory(
-                    eq(CommunityTestConstant.CATEGORY_FULLSTACK.toUpperCase()),
+                    eq(CommunityServiceConstant.CATEGORY_FULLSTACK.toUpperCase()),
                     eq(pageable)
             );
         }
 
         @Test
-        @DisplayName("성공: TIL 목록이 없을 경우 빈 목록 반환")
+        @DisplayName("TIL 목록이 없을 경우 빈 목록 반환")
         void getCommunityTils_WithEmptyResult_ReturnsEmptyList() {
             // given
             CommunityRequestDTO.CommunityListRequest request = CommunityMockBuilder.createCommunityListRequest();
-            Pageable pageable = PageRequest.of(CommunityTestConstant.DEFAULT_PAGE, CommunityTestConstant.DEFAULT_SIZE);
+            Pageable pageable = PageRequest.of(CommunityServiceConstant.DEFAULT_PAGE, CommunityServiceConstant.DEFAULT_SIZE);
 
             given(tilRepository.findRecentPublicTilsByCategory(
-                    eq(CommunityTestConstant.CATEGORY_FULLSTACK.toUpperCase()),
+                    eq(CommunityServiceConstant.CATEGORY_FULLSTACK.toUpperCase()),
                     eq(pageable)
             )).willReturn(Collections.emptyList());
 
@@ -126,28 +119,9 @@ class CommunityServiceTest {
             assertThat(response).isNotNull();
             assertThat(response.getTils()).isEmpty();
             verify(tilRepository).findRecentPublicTilsByCategory(
-                    eq(CommunityTestConstant.CATEGORY_FULLSTACK.toUpperCase()),
+                    eq(CommunityServiceConstant.CATEGORY_FULLSTACK.toUpperCase()),
                     eq(pageable)
             );
-        }
-
-        @Test
-        @DisplayName("성공: 카테고리가 null이거나 ENTIRE인 경우 전체 TIL 목록 반환")
-        void getCommunityTils_WithNullOrEntireCategory_ReturnsAllTils() {
-            // given
-            CommunityRequestDTO.CommunityListRequest request = CommunityMockBuilder.createCommunityListRequestEntire();
-            List<Til> tilList = CommunityMockBuilder.createTilList(2);
-            Pageable pageable = PageRequest.of(CommunityTestConstant.DEFAULT_PAGE, CommunityTestConstant.DEFAULT_SIZE);
-
-            given(tilRepository.findRecentPublicTils(eq(pageable))).willReturn(tilList);
-
-            // when
-            CommunityResponseDTO.CommunityTilListResponse response = communityService.getCommunityTils(request);
-
-            // then
-            assertThat(response).isNotNull();
-            assertThat(response.getTils()).hasSize(2);
-            verify(tilRepository).findRecentPublicTils(eq(pageable));
         }
     }
 
@@ -156,105 +130,109 @@ class CommunityServiceTest {
     class GetTilDetailTest {
 
         @Test
-        @DisplayName("성공: 유효한 tilId로 요청 시 TIL 상세 정보 반환")
+        @DisplayName("유효한 tilId로 요청 시 TIL 상세 정보 반환")
         void getTilDetail_WithValidTilId_Success() {
             // given
-            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
+            given(userRepository.findById(CommunityServiceConstant.VALID_USER_ID))
                     .willReturn(Optional.of(testUser));
-            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+            given(tilRepository.findById(CommunityServiceConstant.VALID_TIL_ID))
                     .willReturn(Optional.of(testTil));
             given(tilRecommendRepository.findByTilIdAndUserId(
-                    CommunityTestConstant.VALID_TIL_ID,
-                    CommunityTestConstant.VALID_USER_ID
+                    CommunityServiceConstant.VALID_TIL_ID,
+                    CommunityServiceConstant.VALID_USER_ID
             )).willReturn(Optional.empty());
 
             // when
             CommunityResponseDTO.CommunityPostDetailResponse response =
-                    communityService.getTilDetail(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID);
+                    communityService.getTilDetail(CommunityServiceConstant.VALID_TIL_ID, CommunityServiceConstant.VALID_USER_ID);
 
             // then
             assertThat(response).isNotNull();
-            assertThat(response.getPostId()).isEqualTo(CommunityTestConstant.VALID_TIL_ID);
-            assertThat(response.getTitle()).isEqualTo(CommunityTestConstant.TIL_TITLE);
-            assertThat(response.getContent()).isEqualTo(CommunityTestConstant.TIL_CONTENT);
+            assertThat(response.getPostId()).isEqualTo(CommunityServiceConstant.VALID_TIL_ID);
+            assertThat(response.getTitle()).isEqualTo(CommunityServiceConstant.TIL_TITLE);
+            assertThat(response.getContent()).isEqualTo(CommunityServiceConstant.TIL_CONTENT);
             assertThat(response.getLiked()).isFalse();
 
-            verify(redisTemplate.opsForZSet()).add(eq(CommunityTestConstant.REDIS_CHANGED_TILS_KEY),
-                    eq(String.valueOf(CommunityTestConstant.VALID_TIL_ID)), anyDouble());
+            verify(redisTemplate.opsForZSet()).add(eq(CommunityServiceConstant.REDIS_CHANGED_TILS_KEY),
+                    eq(String.valueOf(CommunityServiceConstant.VALID_TIL_ID)), anyDouble());
             verify(redisTemplate.opsForValue()).increment(
-                    eq(CommunityTestConstant.REDIS_TIL_VISIT_COUNT_KEY), eq(1L));
+                    eq(CommunityServiceConstant.REDIS_TIL_VISIT_COUNT_KEY), eq(1L));
             verify(tilRepository).save(testTil);
         }
 
         @Test
-        @DisplayName("성공: 조회 시 조회수 1 증가")
+        @DisplayName("조회 시 조회수 1 증가")
         void getTilDetail_IncrementVisitCount_Success() {
             // given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
             int originalVisitCount = testTil.getVisitedCount();
-            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+            given(userRepository.findById(CommunityServiceConstant.VALID_USER_ID))
                     .willReturn(Optional.of(testUser));
-            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+            given(tilRepository.findById(CommunityServiceConstant.VALID_TIL_ID))
                     .willReturn(Optional.of(testTil));
             given(tilRecommendRepository.findByTilIdAndUserId(anyLong(), anyLong()))
                     .willReturn(Optional.empty());
 
             // when
-            communityService.getTilDetail(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID);
+            communityService.getTilDetail(CommunityServiceConstant.VALID_TIL_ID, CommunityServiceConstant.VALID_USER_ID);
 
             // then
             assertThat(testTil.getVisitedCount()).isEqualTo(originalVisitCount + 1);
             verify(redisTemplate.opsForValue()).increment(
-                    eq(CommunityTestConstant.REDIS_TIL_VISIT_COUNT_KEY), eq(1L));
+                    eq(CommunityServiceConstant.REDIS_TIL_VISIT_COUNT_KEY), eq(1L));
         }
 
         @Test
-        @DisplayName("실패: 존재하지 않는 tilId 요청 시 RuntimeException 발생")
+        @DisplayName("존재하지 않는 tilId 요청 시 RuntimeException 발생")
         void getTilDetail_WithInvalidTilId_ThrowsException() {
             // given
-            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+            given(userRepository.findById(CommunityServiceConstant.VALID_USER_ID))
                     .willReturn(Optional.of(testUser));
-            given(tilRepository.findById(CommunityTestConstant.INVALID_TIL_ID))
+            given(tilRepository.findById(CommunityServiceConstant.INVALID_TIL_ID))
                     .willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() ->
-                    communityService.getTilDetail(CommunityTestConstant.INVALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    communityService.getTilDetail(CommunityServiceConstant.INVALID_TIL_ID, CommunityServiceConstant.VALID_USER_ID))
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
+                    .hasMessage(CommunityServiceConstant.ERROR_TIL_NOT_FOUND);
         }
 
         @Test
-        @DisplayName("실패: 비공개 TIL 요청 시 RuntimeException 발생")
+        @DisplayName("비공개 TIL 요청 시 RuntimeException 발생")
         void getTilDetail_WithPrivateTil_ThrowsException() {
             // given
             Til privateTil = CommunityMockBuilder.createPrivateTil();
-            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+            given(userRepository.findById(CommunityServiceConstant.VALID_USER_ID))
                     .willReturn(Optional.of(testUser));
-            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+            given(tilRepository.findById(CommunityServiceConstant.VALID_TIL_ID))
                     .willReturn(Optional.of(privateTil));
 
             // when & then
             assertThatThrownBy(() ->
-                    communityService.getTilDetail(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    communityService.getTilDetail(CommunityServiceConstant.VALID_TIL_ID, CommunityServiceConstant.VALID_USER_ID))
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
+                    .hasMessage(CommunityServiceConstant.ERROR_TIL_NOT_FOUND);
         }
 
         @Test
-        @DisplayName("실패: 삭제된 TIL 요청 시 RuntimeException 발생")
+        @DisplayName("삭제된 TIL 요청 시 RuntimeException 발생")
         void getTilDetail_WithDeletedTil_ThrowsException() {
             // given
             Til deletedTil = CommunityMockBuilder.createDeletedTil();
-            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+            given(userRepository.findById(CommunityServiceConstant.VALID_USER_ID))
                     .willReturn(Optional.of(testUser));
-            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+            given(tilRepository.findById(CommunityServiceConstant.VALID_TIL_ID))
                     .willReturn(Optional.of(deletedTil));
 
             // when & then
             assertThatThrownBy(() ->
-                    communityService.getTilDetail(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    communityService.getTilDetail(CommunityServiceConstant.VALID_TIL_ID, CommunityServiceConstant.VALID_USER_ID))
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
+                    .hasMessage(CommunityServiceConstant.ERROR_TIL_NOT_FOUND);
         }
     }
 
@@ -263,24 +241,26 @@ class CommunityServiceTest {
     class ToggleTilLikeTest {
 
         @Test
-        @DisplayName("성공: 좋아요하지 않은 TIL에 좋아요 시 liked=true, 좋아요수 1 증가")
+        @DisplayName("좋아요하지 않은 TIL에 좋아요 : liked=true, 좋아요수 1 증가")
         void toggleTilLike_AddLike_Success() {
             // given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
             int originalLikeCount = testTil.getRecommendCount();
-            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+            given(userRepository.findById(CommunityServiceConstant.VALID_USER_ID))
                     .willReturn(Optional.of(testUser));
-            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+            given(tilRepository.findById(CommunityServiceConstant.VALID_TIL_ID))
                     .willReturn(Optional.of(testTil));
             given(tilRecommendRepository.findByTilIdAndUserId(
-                    CommunityTestConstant.VALID_TIL_ID,
-                    CommunityTestConstant.VALID_USER_ID
+                    CommunityServiceConstant.VALID_TIL_ID,
+                    CommunityServiceConstant.VALID_USER_ID
             )).willReturn(Optional.empty());
             given(tilRecommendRepository.save(any(TilRecommend.class)))
                     .willReturn(testRecommend);
 
             // when
             CommunityResponseDTO.CommunityLikeResponse response =
-                    communityService.toggleTilLike(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID);
+                    communityService.toggleTilLike(CommunityServiceConstant.VALID_TIL_ID, CommunityServiceConstant.VALID_USER_ID);
 
             // then
             assertThat(response.getLiked()).isTrue();
@@ -289,27 +269,29 @@ class CommunityServiceTest {
 
             verify(tilRecommendRepository).save(any(TilRecommend.class));
             verify(redisTemplate.opsForValue()).increment(
-                    eq(CommunityTestConstant.REDIS_TIL_LIKE_COUNT_KEY), eq(1L));
+                    eq(CommunityServiceConstant.REDIS_TIL_LIKE_COUNT_KEY), eq(1L));
             verify(tilRepository).save(testTil);
         }
 
         @Test
-        @DisplayName("성공: 이미 좋아요한 TIL에 좋아요 시 liked=false, 좋아요수 1 감소")
+        @DisplayName("이미 좋아요한 TIL에 좋아요 : liked=false, 좋아요수 1 감소")
         void toggleTilLike_RemoveLike_Success() {
             // given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
             int originalLikeCount = testTil.getRecommendCount();
-            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+            given(userRepository.findById(CommunityServiceConstant.VALID_USER_ID))
                     .willReturn(Optional.of(testUser));
-            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+            given(tilRepository.findById(CommunityServiceConstant.VALID_TIL_ID))
                     .willReturn(Optional.of(testTil));
             given(tilRecommendRepository.findByTilIdAndUserId(
-                    CommunityTestConstant.VALID_TIL_ID,
-                    CommunityTestConstant.VALID_USER_ID
+                    CommunityServiceConstant.VALID_TIL_ID,
+                    CommunityServiceConstant.VALID_USER_ID
             )).willReturn(Optional.of(testRecommend));
 
             // when
             CommunityResponseDTO.CommunityLikeResponse response =
-                    communityService.toggleTilLike(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID);
+                    communityService.toggleTilLike(CommunityServiceConstant.VALID_TIL_ID, CommunityServiceConstant.VALID_USER_ID);
 
             // then
             assertThat(response.getLiked()).isFalse();
@@ -318,72 +300,58 @@ class CommunityServiceTest {
 
             verify(tilRecommendRepository).delete(testRecommend);
             verify(redisTemplate.opsForValue()).increment(
-                    eq(CommunityTestConstant.REDIS_TIL_LIKE_COUNT_KEY), eq(-1L));
+                    eq(CommunityServiceConstant.REDIS_TIL_LIKE_COUNT_KEY), eq(-1L));
             verify(tilRepository).save(testTil);
         }
 
         @Test
-        @DisplayName("실패: 존재하지 않는 tilId 요청 시 RuntimeException 발생")
+        @DisplayName("존재하지 않는 tilId 요청 시 RuntimeException 발생")
         void toggleTilLike_WithInvalidTilId_ThrowsException() {
             // given
-            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+            given(userRepository.findById(CommunityServiceConstant.VALID_USER_ID))
                     .willReturn(Optional.of(testUser));
-            given(tilRepository.findById(CommunityTestConstant.INVALID_TIL_ID))
+            given(tilRepository.findById(CommunityServiceConstant.INVALID_TIL_ID))
                     .willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() ->
-                    communityService.toggleTilLike(CommunityTestConstant.INVALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    communityService.toggleTilLike(CommunityServiceConstant.INVALID_TIL_ID, CommunityServiceConstant.VALID_USER_ID))
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
+                    .hasMessage(CommunityServiceConstant.ERROR_TIL_NOT_FOUND);
         }
 
         @Test
-        @DisplayName("실패: 비공개 TIL에 좋아요 시도 시 RuntimeException 발생")
+        @DisplayName("비공개 TIL에 좋아요 시도 시 RuntimeException 발생")
         void toggleTilLike_WithPrivateTil_ThrowsException() {
             // given
             Til privateTil = CommunityMockBuilder.createPrivateTil();
-            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+            given(userRepository.findById(CommunityServiceConstant.VALID_USER_ID))
                     .willReturn(Optional.of(testUser));
-            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+            given(tilRepository.findById(CommunityServiceConstant.VALID_TIL_ID))
                     .willReturn(Optional.of(privateTil));
 
             // when & then
             assertThatThrownBy(() ->
-                    communityService.toggleTilLike(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    communityService.toggleTilLike(CommunityServiceConstant.VALID_TIL_ID, CommunityServiceConstant.VALID_USER_ID))
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
+                    .hasMessage(CommunityServiceConstant.ERROR_TIL_NOT_FOUND);
         }
 
         @Test
-        @DisplayName("실패: 삭제된 TIL에 좋아요 시도 시 RuntimeException 발생")
+        @DisplayName("삭제된 TIL에 좋아요 시도 시 RuntimeException 발생")
         void toggleTilLike_WithDeletedTil_ThrowsException() {
             // given
             Til deletedTil = CommunityMockBuilder.createDeletedTil();
-            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+            given(userRepository.findById(CommunityServiceConstant.VALID_USER_ID))
                     .willReturn(Optional.of(testUser));
-            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+            given(tilRepository.findById(CommunityServiceConstant.VALID_TIL_ID))
                     .willReturn(Optional.of(deletedTil));
 
             // when & then
             assertThatThrownBy(() ->
-                    communityService.toggleTilLike(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    communityService.toggleTilLike(CommunityServiceConstant.VALID_TIL_ID, CommunityServiceConstant.VALID_USER_ID))
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("실패: 존재하지 않는 userId 요청 시 RuntimeException 발생")
-        void toggleTilLike_WithInvalidUserId_ThrowsException() {
-            // given
-            given(userRepository.findById(CommunityTestConstant.INVALID_USER_ID))
-                    .willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() ->
-                    communityService.toggleTilLike(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.INVALID_USER_ID))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessage(CommunityTestConstant.ERROR_USER_NOT_FOUND);
+                    .hasMessage(CommunityServiceConstant.ERROR_TIL_NOT_FOUND);
         }
     }
 }

--- a/src/test/java/com/youtil/Api/Community/Service/CommunityServiceTest.java
+++ b/src/test/java/com/youtil/Api/Community/Service/CommunityServiceTest.java
@@ -1,0 +1,389 @@
+package com.youtil.Api.Community.Service;
+
+import com.youtil.Api.Community.Dto.CommunityRequestDTO;
+import com.youtil.Api.Community.Dto.CommunityResponseDTO;
+import com.youtil.Model.Til;
+import com.youtil.Model.TilRecommend;
+import com.youtil.Model.User;
+import com.youtil.Repository.TilRecommendRepository;
+import com.youtil.Repository.TilRepository;
+import com.youtil.Repository.UserRepository;
+import com.youtil.Util.EntityValidator;
+import com.youtil.constant.CommunityTestConstant;
+import com.youtil.Mock.CommunityMockBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommunityService 테스트")
+class CommunityServiceTest {
+
+    @InjectMocks
+    private CommunityService communityService;
+
+    @Mock
+    private TilRepository tilRepository;
+
+    @Mock
+    private TilRecommendRepository tilRecommendRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EntityValidator entityValidator;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private ZSetOperations<String, String> zSetOperations;
+
+    private User testUser;
+    private Til testTil;
+    private TilRecommend testRecommend;
+
+    @BeforeEach
+    void setUp() {
+        testUser = CommunityMockBuilder.createUser();
+        testTil = CommunityMockBuilder.createPublicTil();
+        testRecommend = CommunityMockBuilder.createTilRecommend();
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
+    }
+
+    @Nested
+    @DisplayName("커뮤니티 목록 조회 테스트")
+    class GetCommunityTilsTest {
+
+        @Test
+        @DisplayName("성공: 유효한 카테고리로 요청 시 해당 카테고리 TIL 목록 반환")
+        void getCommunityTils_WithValidCategory_Success() {
+            // given
+            CommunityRequestDTO.CommunityListRequest request = CommunityMockBuilder.createCommunityListRequest();
+            List<Til> tilList = CommunityMockBuilder.createTilList(2);
+            Pageable pageable = PageRequest.of(CommunityTestConstant.DEFAULT_PAGE, CommunityTestConstant.DEFAULT_SIZE);
+
+            given(tilRepository.findRecentPublicTilsByCategory(
+                    eq(CommunityTestConstant.CATEGORY_FULLSTACK.toUpperCase()),
+                    eq(pageable)
+            )).willReturn(tilList);
+
+            // when
+            CommunityResponseDTO.CommunityTilListResponse response = communityService.getCommunityTils(request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getTils()).hasSize(2);
+            assertThat(response.getTils().get(0).getCategory()).isEqualTo(CommunityTestConstant.TIL_CATEGORY);
+            verify(tilRepository).findRecentPublicTilsByCategory(
+                    eq(CommunityTestConstant.CATEGORY_FULLSTACK.toUpperCase()),
+                    eq(pageable)
+            );
+        }
+
+        @Test
+        @DisplayName("성공: TIL 목록이 없을 경우 빈 목록 반환")
+        void getCommunityTils_WithEmptyResult_ReturnsEmptyList() {
+            // given
+            CommunityRequestDTO.CommunityListRequest request = CommunityMockBuilder.createCommunityListRequest();
+            Pageable pageable = PageRequest.of(CommunityTestConstant.DEFAULT_PAGE, CommunityTestConstant.DEFAULT_SIZE);
+
+            given(tilRepository.findRecentPublicTilsByCategory(
+                    eq(CommunityTestConstant.CATEGORY_FULLSTACK.toUpperCase()),
+                    eq(pageable)
+            )).willReturn(Collections.emptyList());
+
+            // when
+            CommunityResponseDTO.CommunityTilListResponse response = communityService.getCommunityTils(request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getTils()).isEmpty();
+            verify(tilRepository).findRecentPublicTilsByCategory(
+                    eq(CommunityTestConstant.CATEGORY_FULLSTACK.toUpperCase()),
+                    eq(pageable)
+            );
+        }
+
+        @Test
+        @DisplayName("성공: 카테고리가 null이거나 ENTIRE인 경우 전체 TIL 목록 반환")
+        void getCommunityTils_WithNullOrEntireCategory_ReturnsAllTils() {
+            // given
+            CommunityRequestDTO.CommunityListRequest request = CommunityMockBuilder.createCommunityListRequestEntire();
+            List<Til> tilList = CommunityMockBuilder.createTilList(2);
+            Pageable pageable = PageRequest.of(CommunityTestConstant.DEFAULT_PAGE, CommunityTestConstant.DEFAULT_SIZE);
+
+            given(tilRepository.findRecentPublicTils(eq(pageable))).willReturn(tilList);
+
+            // when
+            CommunityResponseDTO.CommunityTilListResponse response = communityService.getCommunityTils(request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getTils()).hasSize(2);
+            verify(tilRepository).findRecentPublicTils(eq(pageable));
+        }
+    }
+
+    @Nested
+    @DisplayName("커뮤니티 게시글 상세 조회 테스트")
+    class GetTilDetailTest {
+
+        @Test
+        @DisplayName("성공: 유효한 tilId로 요청 시 TIL 상세 정보 반환")
+        void getTilDetail_WithValidTilId_Success() {
+            // given
+            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+                    .willReturn(Optional.of(testUser));
+            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+                    .willReturn(Optional.of(testTil));
+            given(tilRecommendRepository.findByTilIdAndUserId(
+                    CommunityTestConstant.VALID_TIL_ID,
+                    CommunityTestConstant.VALID_USER_ID
+            )).willReturn(Optional.empty());
+
+            // when
+            CommunityResponseDTO.CommunityPostDetailResponse response =
+                    communityService.getTilDetail(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getPostId()).isEqualTo(CommunityTestConstant.VALID_TIL_ID);
+            assertThat(response.getTitle()).isEqualTo(CommunityTestConstant.TIL_TITLE);
+            assertThat(response.getContent()).isEqualTo(CommunityTestConstant.TIL_CONTENT);
+            assertThat(response.getLiked()).isFalse();
+
+            verify(redisTemplate.opsForZSet()).add(eq(CommunityTestConstant.REDIS_CHANGED_TILS_KEY),
+                    eq(String.valueOf(CommunityTestConstant.VALID_TIL_ID)), anyDouble());
+            verify(redisTemplate.opsForValue()).increment(
+                    eq(CommunityTestConstant.REDIS_TIL_VISIT_COUNT_KEY), eq(1L));
+            verify(tilRepository).save(testTil);
+        }
+
+        @Test
+        @DisplayName("성공: 조회 시 조회수 1 증가")
+        void getTilDetail_IncrementVisitCount_Success() {
+            // given
+            int originalVisitCount = testTil.getVisitedCount();
+            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+                    .willReturn(Optional.of(testUser));
+            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+                    .willReturn(Optional.of(testTil));
+            given(tilRecommendRepository.findByTilIdAndUserId(anyLong(), anyLong()))
+                    .willReturn(Optional.empty());
+
+            // when
+            communityService.getTilDetail(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID);
+
+            // then
+            assertThat(testTil.getVisitedCount()).isEqualTo(originalVisitCount + 1);
+            verify(redisTemplate.opsForValue()).increment(
+                    eq(CommunityTestConstant.REDIS_TIL_VISIT_COUNT_KEY), eq(1L));
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 tilId 요청 시 RuntimeException 발생")
+        void getTilDetail_WithInvalidTilId_ThrowsException() {
+            // given
+            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+                    .willReturn(Optional.of(testUser));
+            given(tilRepository.findById(CommunityTestConstant.INVALID_TIL_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() ->
+                    communityService.getTilDetail(CommunityTestConstant.INVALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 비공개 TIL 요청 시 RuntimeException 발생")
+        void getTilDetail_WithPrivateTil_ThrowsException() {
+            // given
+            Til privateTil = CommunityMockBuilder.createPrivateTil();
+            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+                    .willReturn(Optional.of(testUser));
+            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+                    .willReturn(Optional.of(privateTil));
+
+            // when & then
+            assertThatThrownBy(() ->
+                    communityService.getTilDetail(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 삭제된 TIL 요청 시 RuntimeException 발생")
+        void getTilDetail_WithDeletedTil_ThrowsException() {
+            // given
+            Til deletedTil = CommunityMockBuilder.createDeletedTil();
+            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+                    .willReturn(Optional.of(testUser));
+            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+                    .willReturn(Optional.of(deletedTil));
+
+            // when & then
+            assertThatThrownBy(() ->
+                    communityService.getTilDetail(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("TIL 좋아요 토글 테스트")
+    class ToggleTilLikeTest {
+
+        @Test
+        @DisplayName("성공: 좋아요하지 않은 TIL에 좋아요 시 liked=true, 좋아요수 1 증가")
+        void toggleTilLike_AddLike_Success() {
+            // given
+            int originalLikeCount = testTil.getRecommendCount();
+            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+                    .willReturn(Optional.of(testUser));
+            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+                    .willReturn(Optional.of(testTil));
+            given(tilRecommendRepository.findByTilIdAndUserId(
+                    CommunityTestConstant.VALID_TIL_ID,
+                    CommunityTestConstant.VALID_USER_ID
+            )).willReturn(Optional.empty());
+            given(tilRecommendRepository.save(any(TilRecommend.class)))
+                    .willReturn(testRecommend);
+
+            // when
+            CommunityResponseDTO.CommunityLikeResponse response =
+                    communityService.toggleTilLike(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID);
+
+            // then
+            assertThat(response.getLiked()).isTrue();
+            assertThat(response.getLikeCount()).isEqualTo(originalLikeCount + 1);
+            assertThat(testTil.getRecommendCount()).isEqualTo(originalLikeCount + 1);
+
+            verify(tilRecommendRepository).save(any(TilRecommend.class));
+            verify(redisTemplate.opsForValue()).increment(
+                    eq(CommunityTestConstant.REDIS_TIL_LIKE_COUNT_KEY), eq(1L));
+            verify(tilRepository).save(testTil);
+        }
+
+        @Test
+        @DisplayName("성공: 이미 좋아요한 TIL에 좋아요 시 liked=false, 좋아요수 1 감소")
+        void toggleTilLike_RemoveLike_Success() {
+            // given
+            int originalLikeCount = testTil.getRecommendCount();
+            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+                    .willReturn(Optional.of(testUser));
+            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+                    .willReturn(Optional.of(testTil));
+            given(tilRecommendRepository.findByTilIdAndUserId(
+                    CommunityTestConstant.VALID_TIL_ID,
+                    CommunityTestConstant.VALID_USER_ID
+            )).willReturn(Optional.of(testRecommend));
+
+            // when
+            CommunityResponseDTO.CommunityLikeResponse response =
+                    communityService.toggleTilLike(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID);
+
+            // then
+            assertThat(response.getLiked()).isFalse();
+            assertThat(response.getLikeCount()).isEqualTo(originalLikeCount - 1);
+            assertThat(testTil.getRecommendCount()).isEqualTo(originalLikeCount - 1);
+
+            verify(tilRecommendRepository).delete(testRecommend);
+            verify(redisTemplate.opsForValue()).increment(
+                    eq(CommunityTestConstant.REDIS_TIL_LIKE_COUNT_KEY), eq(-1L));
+            verify(tilRepository).save(testTil);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 tilId 요청 시 RuntimeException 발생")
+        void toggleTilLike_WithInvalidTilId_ThrowsException() {
+            // given
+            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+                    .willReturn(Optional.of(testUser));
+            given(tilRepository.findById(CommunityTestConstant.INVALID_TIL_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() ->
+                    communityService.toggleTilLike(CommunityTestConstant.INVALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 비공개 TIL에 좋아요 시도 시 RuntimeException 발생")
+        void toggleTilLike_WithPrivateTil_ThrowsException() {
+            // given
+            Til privateTil = CommunityMockBuilder.createPrivateTil();
+            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+                    .willReturn(Optional.of(testUser));
+            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+                    .willReturn(Optional.of(privateTil));
+
+            // when & then
+            assertThatThrownBy(() ->
+                    communityService.toggleTilLike(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 삭제된 TIL에 좋아요 시도 시 RuntimeException 발생")
+        void toggleTilLike_WithDeletedTil_ThrowsException() {
+            // given
+            Til deletedTil = CommunityMockBuilder.createDeletedTil();
+            given(userRepository.findById(CommunityTestConstant.VALID_USER_ID))
+                    .willReturn(Optional.of(testUser));
+            given(tilRepository.findById(CommunityTestConstant.VALID_TIL_ID))
+                    .willReturn(Optional.of(deletedTil));
+
+            // when & then
+            assertThatThrownBy(() ->
+                    communityService.toggleTilLike(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.VALID_USER_ID))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage(CommunityTestConstant.ERROR_TIL_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 userId 요청 시 RuntimeException 발생")
+        void toggleTilLike_WithInvalidUserId_ThrowsException() {
+            // given
+            given(userRepository.findById(CommunityTestConstant.INVALID_USER_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() ->
+                    communityService.toggleTilLike(CommunityTestConstant.VALID_TIL_ID, CommunityTestConstant.INVALID_USER_ID))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage(CommunityTestConstant.ERROR_USER_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/com/youtil/Constants/CommunityServiceConstant.java
+++ b/src/test/java/com/youtil/Constants/CommunityServiceConstant.java
@@ -1,11 +1,11 @@
-package com.youtil.constant;
+package com.youtil.Constants;
 
 import com.youtil.Common.Enums.Status;
 
 /**
  * 커뮤니티 테스트 상수
  */
-public class CommunityTestConstant {
+public class CommunityServiceConstant {
 
     // 사용자 관련 상수
     public static final Long VALID_USER_ID = 1L;

--- a/src/test/java/com/youtil/Constants/CommunityTestConstant.java
+++ b/src/test/java/com/youtil/Constants/CommunityTestConstant.java
@@ -1,0 +1,53 @@
+package com.youtil.constant;
+
+import com.youtil.Common.Enums.Status;
+
+/**
+ * 커뮤니티 테스트 상수
+ */
+public class CommunityTestConstant {
+
+    // 사용자 관련 상수
+    public static final Long VALID_USER_ID = 1L;
+    public static final Long INVALID_USER_ID = 999L;
+    public static final String USER_NICKNAME = "testuser";
+    public static final String USER_EMAIL = "test@example.com";
+    public static final String USER_PROFILE_IMAGE = "profile.jpg";
+
+    // TIL 관련 상수
+    public static final Long VALID_TIL_ID = 1L;
+    public static final Long INVALID_TIL_ID = 999L;
+    public static final String TIL_TITLE = "테스트 TIL 제목";
+    public static final String TIL_CONTENT = "테스트 TIL 내용입니다.";
+    public static final String TIL_CATEGORY = "FULLSTACK";
+    public static final java.util.List<String> TIL_TAG_LIST = java.util.Arrays.asList("Spring", "Java", "Test");
+    public static final java.util.List<String> TIL_TAG_LIST_1 = java.util.Arrays.asList("Java", "Spring");
+    public static final java.util.List<String> TIL_TAG_LIST_2 = java.util.Arrays.asList("React", "JavaScript");
+    public static final Boolean TIL_IS_DISPLAY_TRUE = true;
+    public static final Boolean TIL_IS_DISPLAY_FALSE = false;
+    public static final Status TIL_STATUS_ACTIVE = Status.active;
+    public static final Status TIL_STATUS_DEACTIVE = Status.deactive;
+    public static final Integer TIL_RECOMMEND_COUNT = 5;
+    public static final Integer TIL_VISITED_COUNT = 10;
+    public static final Integer TIL_COMMENTS_COUNT = 3;
+
+    // 페이징 관련 상수
+    public static final Integer DEFAULT_PAGE = 0;
+    public static final Integer DEFAULT_SIZE = 10;
+
+    // 카테고리 관련 상수
+    public static final String CATEGORY_FULLSTACK = "FULLSTACK";
+    public static final String CATEGORY_ENTIRE = "ENTIRE";
+
+    // Redis 관련 상수
+    public static final String REDIS_TIL_LIKE_COUNT_KEY = "til:1:like_count";
+    public static final String REDIS_TIL_VISIT_COUNT_KEY = "til:1:visit_count";
+    public static final String REDIS_CHANGED_TILS_KEY = "changed:tils";
+
+    // 좋아요 관련 상수
+    public static final Long VALID_RECOMMEND_ID = 1L;
+
+    // 에러 메시지 상수
+    public static final String ERROR_USER_NOT_FOUND = "해당하는 유저가 존재하지 않습니다.";
+    public static final String ERROR_TIL_NOT_FOUND = "해당하는 게시글이 존재하지 않습니다.";
+}

--- a/src/test/java/com/youtil/Mock/CommunityMockBuilder.java
+++ b/src/test/java/com/youtil/Mock/CommunityMockBuilder.java
@@ -1,0 +1,185 @@
+package com.youtil.Mock;
+
+import com.youtil.Api.Community.Dto.CommunityRequestDTO;
+import com.youtil.Common.Enums.Status;
+import com.youtil.Model.Til;
+import com.youtil.Model.TilRecommend;
+import com.youtil.Model.User;
+import com.youtil.constant.CommunityTestConstant;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 커뮤니티 테스트용 Mock 객체 생성 클래스
+ */
+public class CommunityMockBuilder {
+
+    /**
+     * 테스트용 User 객체 생성
+     */
+    public static User createUser() {
+        return User.builder()
+                .id(CommunityTestConstant.VALID_USER_ID)
+                .email(CommunityTestConstant.USER_EMAIL)
+                .nickname(CommunityTestConstant.USER_NICKNAME)
+                .profileImageUrl(CommunityTestConstant.USER_PROFILE_IMAGE)
+                .status(Status.active)
+                .build();
+    }
+
+    /**
+     * 테스트용 User 객체 생성 (커스텀 ID)
+     */
+    public static User createUser(Long userId) {
+        return User.builder()
+                .id(userId)
+                .email(CommunityTestConstant.USER_EMAIL)
+                .nickname(CommunityTestConstant.USER_NICKNAME)
+                .profileImageUrl(CommunityTestConstant.USER_PROFILE_IMAGE)
+                .status(Status.active)
+                .build();
+    }
+
+    /**
+     * 테스트용 공개 TIL 객체 생성
+     */
+    public static Til createPublicTil() {
+        User user = createUser();
+        return Til.builder()
+                .id(CommunityTestConstant.VALID_TIL_ID)
+                .user(user)
+                .title(CommunityTestConstant.TIL_TITLE)
+                .content(CommunityTestConstant.TIL_CONTENT)
+                .isDisplay(CommunityTestConstant.TIL_IS_DISPLAY_TRUE)
+                .category(CommunityTestConstant.TIL_CATEGORY)
+                .tag(CommunityTestConstant.TIL_TAG_LIST)
+                .recommendCount(CommunityTestConstant.TIL_RECOMMEND_COUNT)
+                .visitedCount(CommunityTestConstant.TIL_VISITED_COUNT)
+                .commentsCount(CommunityTestConstant.TIL_COMMENTS_COUNT)
+                .status(CommunityTestConstant.TIL_STATUS_ACTIVE)
+                .build();
+    }
+
+    /**
+     * 테스트용 비공개 TIL 객체 생성
+     */
+    public static Til createPrivateTil() {
+        User user = createUser();
+        return Til.builder()
+                .id(CommunityTestConstant.VALID_TIL_ID)
+                .user(user)
+                .title(CommunityTestConstant.TIL_TITLE)
+                .content(CommunityTestConstant.TIL_CONTENT)
+                .isDisplay(CommunityTestConstant.TIL_IS_DISPLAY_FALSE)
+                .category(CommunityTestConstant.TIL_CATEGORY)
+                .tag(CommunityTestConstant.TIL_TAG_LIST)
+                .recommendCount(CommunityTestConstant.TIL_RECOMMEND_COUNT)
+                .visitedCount(CommunityTestConstant.TIL_VISITED_COUNT)
+                .commentsCount(CommunityTestConstant.TIL_COMMENTS_COUNT)
+                .status(CommunityTestConstant.TIL_STATUS_ACTIVE)
+                .build();
+    }
+
+    /**
+     * 테스트용 삭제된 TIL 객체 생성
+     */
+    public static Til createDeletedTil() {
+        User user = createUser();
+        return Til.builder()
+                .id(CommunityTestConstant.VALID_TIL_ID)
+                .user(user)
+                .title(CommunityTestConstant.TIL_TITLE)
+                .content(CommunityTestConstant.TIL_CONTENT)
+                .isDisplay(CommunityTestConstant.TIL_IS_DISPLAY_TRUE)
+                .category(CommunityTestConstant.TIL_CATEGORY)
+                .tag(CommunityTestConstant.TIL_TAG_LIST)
+                .recommendCount(CommunityTestConstant.TIL_RECOMMEND_COUNT)
+                .visitedCount(CommunityTestConstant.TIL_VISITED_COUNT)
+                .commentsCount(CommunityTestConstant.TIL_COMMENTS_COUNT)
+                .status(CommunityTestConstant.TIL_STATUS_DEACTIVE)
+                .build();
+    }
+
+    /**
+     * 테스트용 TIL 리스트 생성
+     */
+    public static List<Til> createTilList(int count) {
+        User user = createUser();
+        return Arrays.asList(
+                Til.builder()
+                        .id(1L)
+                        .user(user)
+                        .title("TIL 제목 1")
+                        .content("TIL 내용 1")
+                        .isDisplay(true)
+                        .category(CommunityTestConstant.TIL_CATEGORY)
+                        .tag(CommunityTestConstant.TIL_TAG_LIST_1)
+                        .recommendCount(5)
+                        .visitedCount(10)
+                        .commentsCount(3)
+                        .status(Status.active)
+                        .build(),
+                Til.builder()
+                        .id(2L)
+                        .user(user)
+                        .title("TIL 제목 2")
+                        .content("TIL 내용 2")
+                        .isDisplay(true)
+                        .category(CommunityTestConstant.TIL_CATEGORY)
+                        .tag(CommunityTestConstant.TIL_TAG_LIST_2)
+                        .recommendCount(8)
+                        .visitedCount(15)
+                        .commentsCount(7)
+                        .status(Status.active)
+                        .build()
+        );
+    }
+
+    /**
+     * 테스트용 TilRecommend 객체 생성
+     */
+    public static TilRecommend createTilRecommend() {
+        User user = createUser();
+        Til til = createPublicTil();
+        return TilRecommend.builder()
+                .id(CommunityTestConstant.VALID_RECOMMEND_ID)
+                .til(til)
+                .user(user)
+                .build();
+    }
+
+    /**
+     * 테스트용 CommunityListRequest 생성
+     */
+    public static CommunityRequestDTO.CommunityListRequest createCommunityListRequest() {
+        return CommunityRequestDTO.CommunityListRequest.builder()
+                .category(CommunityTestConstant.CATEGORY_FULLSTACK)
+                .page(CommunityTestConstant.DEFAULT_PAGE)
+                .offset(CommunityTestConstant.DEFAULT_SIZE)
+                .build();
+    }
+
+    /**
+     * 테스트용 CommunityListRequest 생성 (카테고리 없음)
+     */
+    public static CommunityRequestDTO.CommunityListRequest createCommunityListRequestWithoutCategory() {
+        return CommunityRequestDTO.CommunityListRequest.builder()
+                .category(null)
+                .page(CommunityTestConstant.DEFAULT_PAGE)
+                .offset(CommunityTestConstant.DEFAULT_SIZE)
+                .build();
+    }
+
+    /**
+     * 테스트용 CommunityListRequest 생성 (전체 카테고리)
+     */
+    public static CommunityRequestDTO.CommunityListRequest createCommunityListRequestEntire() {
+        return CommunityRequestDTO.CommunityListRequest.builder()
+                .category(CommunityTestConstant.CATEGORY_ENTIRE)
+                .page(CommunityTestConstant.DEFAULT_PAGE)
+                .offset(CommunityTestConstant.DEFAULT_SIZE)
+                .build();
+    }
+}

--- a/src/test/java/com/youtil/Mock/CommunityMockBuilder.java
+++ b/src/test/java/com/youtil/Mock/CommunityMockBuilder.java
@@ -1,45 +1,49 @@
 package com.youtil.Mock;
 
 import com.youtil.Api.Community.Dto.CommunityRequestDTO;
+import com.youtil.Constants.CommunityServiceConstant;
 import com.youtil.Common.Enums.Status;
 import com.youtil.Model.Til;
 import com.youtil.Model.TilRecommend;
 import com.youtil.Model.User;
-import com.youtil.constant.CommunityTestConstant;
-
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * 커뮤니티 테스트용 Mock 객체 생성 클래스
- */
 public class CommunityMockBuilder {
 
     /**
      * 테스트용 User 객체 생성
      */
     public static User createUser() {
-        return User.builder()
-                .id(CommunityTestConstant.VALID_USER_ID)
-                .email(CommunityTestConstant.USER_EMAIL)
-                .nickname(CommunityTestConstant.USER_NICKNAME)
-                .profileImageUrl(CommunityTestConstant.USER_PROFILE_IMAGE)
+        User user = User.builder()
+                .id(CommunityServiceConstant.VALID_USER_ID)
+                .email(CommunityServiceConstant.USER_EMAIL)
+                .nickname(CommunityServiceConstant.USER_NICKNAME)
+                .profileImageUrl(CommunityServiceConstant.USER_PROFILE_IMAGE)
                 .status(Status.active)
                 .build();
+
+        // BaseTime 필드 설정
+        setBaseTimeFields(user);
+        return user;
     }
 
     /**
      * 테스트용 User 객체 생성 (커스텀 ID)
      */
     public static User createUser(Long userId) {
-        return User.builder()
+        User user = User.builder()
                 .id(userId)
-                .email(CommunityTestConstant.USER_EMAIL)
-                .nickname(CommunityTestConstant.USER_NICKNAME)
-                .profileImageUrl(CommunityTestConstant.USER_PROFILE_IMAGE)
+                .email(CommunityServiceConstant.USER_EMAIL)
+                .nickname(CommunityServiceConstant.USER_NICKNAME)
+                .profileImageUrl(CommunityServiceConstant.USER_PROFILE_IMAGE)
                 .status(Status.active)
                 .build();
+
+        // BaseTime 필드 설정
+        setBaseTimeFields(user);
+        return user;
     }
 
     /**
@@ -47,19 +51,23 @@ public class CommunityMockBuilder {
      */
     public static Til createPublicTil() {
         User user = createUser();
-        return Til.builder()
-                .id(CommunityTestConstant.VALID_TIL_ID)
+        Til til = Til.builder()
+                .id(CommunityServiceConstant.VALID_TIL_ID)
                 .user(user)
-                .title(CommunityTestConstant.TIL_TITLE)
-                .content(CommunityTestConstant.TIL_CONTENT)
-                .isDisplay(CommunityTestConstant.TIL_IS_DISPLAY_TRUE)
-                .category(CommunityTestConstant.TIL_CATEGORY)
-                .tag(CommunityTestConstant.TIL_TAG_LIST)
-                .recommendCount(CommunityTestConstant.TIL_RECOMMEND_COUNT)
-                .visitedCount(CommunityTestConstant.TIL_VISITED_COUNT)
-                .commentsCount(CommunityTestConstant.TIL_COMMENTS_COUNT)
-                .status(CommunityTestConstant.TIL_STATUS_ACTIVE)
+                .title(CommunityServiceConstant.TIL_TITLE)
+                .content(CommunityServiceConstant.TIL_CONTENT)
+                .isDisplay(CommunityServiceConstant.TIL_IS_DISPLAY_TRUE)
+                .category(CommunityServiceConstant.TIL_CATEGORY)
+                .tag(CommunityServiceConstant.TIL_TAG_LIST)
+                .recommendCount(CommunityServiceConstant.TIL_RECOMMEND_COUNT)
+                .visitedCount(CommunityServiceConstant.TIL_VISITED_COUNT)
+                .commentsCount(CommunityServiceConstant.TIL_COMMENTS_COUNT)
+                .status(CommunityServiceConstant.TIL_STATUS_ACTIVE)
                 .build();
+
+        // BaseTime 필드 설정
+        setBaseTimeFields(til);
+        return til;
     }
 
     /**
@@ -67,19 +75,23 @@ public class CommunityMockBuilder {
      */
     public static Til createPrivateTil() {
         User user = createUser();
-        return Til.builder()
-                .id(CommunityTestConstant.VALID_TIL_ID)
+        Til til = Til.builder()
+                .id(CommunityServiceConstant.VALID_TIL_ID)
                 .user(user)
-                .title(CommunityTestConstant.TIL_TITLE)
-                .content(CommunityTestConstant.TIL_CONTENT)
-                .isDisplay(CommunityTestConstant.TIL_IS_DISPLAY_FALSE)
-                .category(CommunityTestConstant.TIL_CATEGORY)
-                .tag(CommunityTestConstant.TIL_TAG_LIST)
-                .recommendCount(CommunityTestConstant.TIL_RECOMMEND_COUNT)
-                .visitedCount(CommunityTestConstant.TIL_VISITED_COUNT)
-                .commentsCount(CommunityTestConstant.TIL_COMMENTS_COUNT)
-                .status(CommunityTestConstant.TIL_STATUS_ACTIVE)
+                .title(CommunityServiceConstant.TIL_TITLE)
+                .content(CommunityServiceConstant.TIL_CONTENT)
+                .isDisplay(CommunityServiceConstant.TIL_IS_DISPLAY_FALSE)
+                .category(CommunityServiceConstant.TIL_CATEGORY)
+                .tag(CommunityServiceConstant.TIL_TAG_LIST)
+                .recommendCount(CommunityServiceConstant.TIL_RECOMMEND_COUNT)
+                .visitedCount(CommunityServiceConstant.TIL_VISITED_COUNT)
+                .commentsCount(CommunityServiceConstant.TIL_COMMENTS_COUNT)
+                .status(CommunityServiceConstant.TIL_STATUS_ACTIVE)
                 .build();
+
+        // BaseTime 필드 설정
+        setBaseTimeFields(til);
+        return til;
     }
 
     /**
@@ -87,19 +99,23 @@ public class CommunityMockBuilder {
      */
     public static Til createDeletedTil() {
         User user = createUser();
-        return Til.builder()
-                .id(CommunityTestConstant.VALID_TIL_ID)
+        Til til = Til.builder()
+                .id(CommunityServiceConstant.VALID_TIL_ID)
                 .user(user)
-                .title(CommunityTestConstant.TIL_TITLE)
-                .content(CommunityTestConstant.TIL_CONTENT)
-                .isDisplay(CommunityTestConstant.TIL_IS_DISPLAY_TRUE)
-                .category(CommunityTestConstant.TIL_CATEGORY)
-                .tag(CommunityTestConstant.TIL_TAG_LIST)
-                .recommendCount(CommunityTestConstant.TIL_RECOMMEND_COUNT)
-                .visitedCount(CommunityTestConstant.TIL_VISITED_COUNT)
-                .commentsCount(CommunityTestConstant.TIL_COMMENTS_COUNT)
-                .status(CommunityTestConstant.TIL_STATUS_DEACTIVE)
+                .title(CommunityServiceConstant.TIL_TITLE)
+                .content(CommunityServiceConstant.TIL_CONTENT)
+                .isDisplay(CommunityServiceConstant.TIL_IS_DISPLAY_TRUE)
+                .category(CommunityServiceConstant.TIL_CATEGORY)
+                .tag(CommunityServiceConstant.TIL_TAG_LIST)
+                .recommendCount(CommunityServiceConstant.TIL_RECOMMEND_COUNT)
+                .visitedCount(CommunityServiceConstant.TIL_VISITED_COUNT)
+                .commentsCount(CommunityServiceConstant.TIL_COMMENTS_COUNT)
+                .status(CommunityServiceConstant.TIL_STATUS_DEACTIVE)
                 .build();
+
+        // BaseTime 필드 설정
+        setBaseTimeFields(til);
+        return til;
     }
 
     /**
@@ -107,34 +123,40 @@ public class CommunityMockBuilder {
      */
     public static List<Til> createTilList(int count) {
         User user = createUser();
-        return Arrays.asList(
-                Til.builder()
-                        .id(1L)
-                        .user(user)
-                        .title("TIL 제목 1")
-                        .content("TIL 내용 1")
-                        .isDisplay(true)
-                        .category(CommunityTestConstant.TIL_CATEGORY)
-                        .tag(CommunityTestConstant.TIL_TAG_LIST_1)
-                        .recommendCount(5)
-                        .visitedCount(10)
-                        .commentsCount(3)
-                        .status(Status.active)
-                        .build(),
-                Til.builder()
-                        .id(2L)
-                        .user(user)
-                        .title("TIL 제목 2")
-                        .content("TIL 내용 2")
-                        .isDisplay(true)
-                        .category(CommunityTestConstant.TIL_CATEGORY)
-                        .tag(CommunityTestConstant.TIL_TAG_LIST_2)
-                        .recommendCount(8)
-                        .visitedCount(15)
-                        .commentsCount(7)
-                        .status(Status.active)
-                        .build()
-        );
+
+        Til til1 = Til.builder()
+                .id(1L)
+                .user(user)
+                .title("TIL 제목 1")
+                .content("TIL 내용 1")
+                .isDisplay(true)
+                .category(CommunityServiceConstant.TIL_CATEGORY)
+                .tag(CommunityServiceConstant.TIL_TAG_LIST_1)
+                .recommendCount(5)
+                .visitedCount(10)
+                .commentsCount(3)
+                .status(Status.active)
+                .build();
+
+        Til til2 = Til.builder()
+                .id(2L)
+                .user(user)
+                .title("TIL 제목 2")
+                .content("TIL 내용 2")
+                .isDisplay(true)
+                .category(CommunityServiceConstant.TIL_CATEGORY)
+                .tag(CommunityServiceConstant.TIL_TAG_LIST_2)
+                .recommendCount(8)
+                .visitedCount(15)
+                .commentsCount(7)
+                .status(Status.active)
+                .build();
+
+        // BaseTime 필드 설정
+        setBaseTimeFields(til1);
+        setBaseTimeFields(til2);
+
+        return Arrays.asList(til1, til2);
     }
 
     /**
@@ -143,11 +165,14 @@ public class CommunityMockBuilder {
     public static TilRecommend createTilRecommend() {
         User user = createUser();
         Til til = createPublicTil();
-        return TilRecommend.builder()
-                .id(CommunityTestConstant.VALID_RECOMMEND_ID)
+        TilRecommend recommend = TilRecommend.builder()
+                .id(CommunityServiceConstant.VALID_RECOMMEND_ID)
                 .til(til)
                 .user(user)
                 .build();
+
+        setCreatedAtField(recommend);
+        return recommend;
     }
 
     /**
@@ -155,31 +180,62 @@ public class CommunityMockBuilder {
      */
     public static CommunityRequestDTO.CommunityListRequest createCommunityListRequest() {
         return CommunityRequestDTO.CommunityListRequest.builder()
-                .category(CommunityTestConstant.CATEGORY_FULLSTACK)
-                .page(CommunityTestConstant.DEFAULT_PAGE)
-                .offset(CommunityTestConstant.DEFAULT_SIZE)
+                .category(CommunityServiceConstant.CATEGORY_FULLSTACK)
+                .page(CommunityServiceConstant.DEFAULT_PAGE)
+                .offset(CommunityServiceConstant.DEFAULT_SIZE)
                 .build();
     }
 
     /**
-     * 테스트용 CommunityListRequest 생성 (카테고리 없음)
+     * BaseTime을 상속받는 객체의 createdAt, updatedAt 필드 설정
      */
-    public static CommunityRequestDTO.CommunityListRequest createCommunityListRequestWithoutCategory() {
-        return CommunityRequestDTO.CommunityListRequest.builder()
-                .category(null)
-                .page(CommunityTestConstant.DEFAULT_PAGE)
-                .offset(CommunityTestConstant.DEFAULT_SIZE)
-                .build();
+    private static void setBaseTimeFields(Object entity) {
+        try {
+            OffsetDateTime now = OffsetDateTime.now();
+
+            // createdAt 필드 설정 (BaseTime 클래스에서 찾기)
+            java.lang.reflect.Field createdAtField = findFieldInHierarchy(entity.getClass(), "createdAt");
+            if (createdAtField != null) {
+                createdAtField.setAccessible(true);
+                createdAtField.set(entity, now);
+            }
+
+            // updatedAt 필드 설정 (BaseTime 클래스에서 찾기)
+            java.lang.reflect.Field updatedAtField = findFieldInHierarchy(entity.getClass(), "updatedAt");
+            if (updatedAtField != null) {
+                updatedAtField.setAccessible(true);
+                updatedAtField.set(entity, now);
+            }
+        } catch (Exception e) {
+            // 필드 설정에 실패해도 테스트에 영향주지 않도록 로그만 남김
+            System.err.println("BaseTime 필드 설정 실패: " + e.getMessage());
+        }
     }
 
     /**
-     * 테스트용 CommunityListRequest 생성 (전체 카테고리)
+     * TilRecommend의 createdAt 필드 설정
      */
-    public static CommunityRequestDTO.CommunityListRequest createCommunityListRequestEntire() {
-        return CommunityRequestDTO.CommunityListRequest.builder()
-                .category(CommunityTestConstant.CATEGORY_ENTIRE)
-                .page(CommunityTestConstant.DEFAULT_PAGE)
-                .offset(CommunityTestConstant.DEFAULT_SIZE)
-                .build();
+    private static void setCreatedAtField(TilRecommend recommend) {
+        try {
+            java.lang.reflect.Field createdAtField = TilRecommend.class.getDeclaredField("createdAt");
+            createdAtField.setAccessible(true);
+            createdAtField.set(recommend, OffsetDateTime.now());
+        } catch (Exception e) {
+            System.err.println("TilRecommend createdAt 필드 설정 실패: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 클래스 상속 구조에서 특정 필드를 찾는 헬퍼 메서드
+     */
+    private static java.lang.reflect.Field findFieldInHierarchy(Class<?> clazz, String fieldName) {
+        while (clazz != null) {
+            try {
+                return clazz.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
- 제목 : feat(270): 커뮤니티 도메인

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 커뮤니티 게시글 목록 조회
- 커뮤니티 게시글 상세 조회
- 게시글 좋아요 구현

  <br/>

## 🔧 앞으로의 과제

- 방명록 도메인, TIL 도메인
- 인공지능 서버의 response 변경

  <br/>

## ➕ 이슈 링크

#270 

<br/>
