### PR TITLE
 TIL 도메인 테스트코드 (2차 3차 MVP기능)

### DIFF
--- a/src/test/java/com/youtil/Api/Tils/Service/TilUpdateDeleteApiTest.java
+++ b/src/test/java/com/youtil/Api/Tils/Service/TilUpdateDeleteApiTest.java
@@ -1,0 +1,504 @@
+package com.youtil.Api.Tils.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.youtil.Api.Tils.Controller.TilUpdateDeleteController;
+import com.youtil.Api.Tils.Dto.TilRequestDTO;
+import com.youtil.Api.Tils.Dto.TilResponseDTO;
+import com.youtil.Constants.TilTestConstants;
+import com.youtil.Mock.TilMockBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest({TilUpdateDeleteController.class})
+@DisplayName("TIL 수정/삭제 API 테스트")
+class TilUpdateDeleteApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private TilCommendService tilCommendService;
+
+    private TilRequestDTO.UpdateTilRequest validUpdateRequest;
+    private TilResponseDTO.TilDetailResponse tilDetailResponse;
+
+    @BeforeEach
+    void setUp() {
+        validUpdateRequest = TilMockBuilder.createUpdateTilRequest();
+        tilDetailResponse = TilMockBuilder.createTilDetailResponse();
+    }
+
+    @Nested
+    @DisplayName("TIL 수정")
+    class TilUpdateTest {
+
+        @Nested
+        @DisplayName("성공 시나리오")
+        class SuccessScenarios {
+
+            @Test
+            @DisplayName("유효한 tilId, title로 요청 시 TIL 제목 수정 성공")
+            @WithMockUser(username = "1")
+            void updateTil_ValidRequest_Success() throws Exception {
+                // given
+                given(tilCommendService.getTilById(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID)))
+                        .willReturn(tilDetailResponse);
+                given(tilCommendService.updateTil(eq(TilTestConstants.TEST_TIL_ID), any(), eq(TilTestConstants.TEST_USER_ID)))
+                        .willReturn(tilDetailResponse);
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validUpdateRequest)))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.success").value(true))
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_200))
+                        .andExpect(jsonPath("$.message").value(TilTestConstants.SUCCESS_TIL_UPDATED))
+                        .andExpect(jsonPath("$.data.id").value(TilTestConstants.TEST_TIL_ID))
+                        .andExpect(jsonPath("$.data.title").value(TilTestConstants.TEST_TIL_TITLE))
+                        .andExpect(jsonPath("$.data.userId").value(TilTestConstants.TEST_USER_ID));
+            }
+
+            @Test
+            @DisplayName("본인이 작성한 TIL만 수정 성공")
+            @WithMockUser(username = "1")
+            void updateTil_OwnerRequest_Success() throws Exception {
+                // given
+                given(tilCommendService.getTilById(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID)))
+                        .willReturn(tilDetailResponse);
+                given(tilCommendService.updateTil(eq(TilTestConstants.TEST_TIL_ID), any(), eq(TilTestConstants.TEST_USER_ID)))
+                        .willReturn(tilDetailResponse);
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validUpdateRequest)))
+                        .andExpect(status().isOk());
+
+                then(tilCommendService).should().updateTil(
+                        eq(TilTestConstants.TEST_TIL_ID),
+                        argThat(request -> request.getTitle().equals(TilTestConstants.UPDATED_TIL_TITLE)),
+                        eq(TilTestConstants.TEST_USER_ID)
+                );
+            }
+
+            @Test
+            @DisplayName("40자 이내의 제목으로 수정 시 수정 성공")
+            @WithMockUser(username = "1")
+            void updateTil_ValidTitleLength_Success() throws Exception {
+                // given
+                TilRequestDTO.UpdateTilRequest request = TilMockBuilder.createUpdateTilRequestWith40CharsTitle();
+                TilResponseDTO.TilDetailResponse response = TilMockBuilder.createTilDetailResponse();
+
+                given(tilCommendService.getTilById(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID)))
+                        .willReturn(response);
+                given(tilCommendService.updateTil(eq(TilTestConstants.TEST_TIL_ID), any(), eq(TilTestConstants.TEST_USER_ID)))
+                        .willReturn(response);
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.title").value(TilTestConstants.TEST_TIL_TITLE));
+
+                then(tilCommendService).should().updateTil(
+                        eq(TilTestConstants.TEST_TIL_ID),
+                        argThat(req -> req.getTitle().equals(TilTestConstants.VALID_TITLE_40_CHARS)),
+                        eq(TilTestConstants.TEST_USER_ID)
+                );
+            }
+
+            @Test
+            @DisplayName("수정 후 updatedAt 수정")
+            @WithMockUser(username = "1")
+            void updateTil_UpdatedAtChanged() throws Exception {
+                // given
+                given(tilCommendService.getTilById(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID)))
+                        .willReturn(tilDetailResponse);
+                given(tilCommendService.updateTil(eq(TilTestConstants.TEST_TIL_ID), any(), eq(TilTestConstants.TEST_USER_ID)))
+                        .willReturn(tilDetailResponse);
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validUpdateRequest)))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.updatedAt").exists())
+                        .andExpect(jsonPath("$.data.title").value(TilTestConstants.TEST_TIL_TITLE))
+                        .andExpect(jsonPath("$.data.id").value(TilTestConstants.TEST_TIL_ID));
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 시나리오")
+        class FailureScenarios {
+
+            @Test
+            @DisplayName("tilId null 전달 시 HTTP 400 Bad Request")
+            @WithMockUser(username = "1")
+            void updateTil_NullTilId_BadRequest() throws Exception {
+                // given
+                TilRequestDTO.UpdateTilRequest request = TilMockBuilder.createUpdateTilRequestWithNullTilId();
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_400))
+                        .andExpect(jsonPath("$.success").value(false));
+            }
+
+            @Test
+            @DisplayName("title null 전달 시 HTTP 400 Bad Request")
+            @WithMockUser(username = "1")
+            void updateTil_NullTitle_BadRequest() throws Exception {
+                // given
+                TilRequestDTO.UpdateTilRequest request = TilMockBuilder.createUpdateTilRequestWithNullTitle();
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_400))
+                        .andExpect(jsonPath("$.success").value(false));
+            }
+
+            @Test
+            @DisplayName("title 빈 문자열 전달 시 HTTP 400 Bad Request")
+            @WithMockUser(username = "1")
+            void updateTil_EmptyTitle_BadRequest() throws Exception {
+                // given
+                TilRequestDTO.UpdateTilRequest request = TilMockBuilder.createUpdateTilRequest(
+                        TilTestConstants.TEST_TIL_ID, ""
+                );
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_400));
+            }
+
+            @Test
+            @DisplayName("title 공백만 포함 시 HTTP 400 Bad Request")
+            @WithMockUser(username = "1")
+            void updateTil_WhitespaceOnlyTitle_BadRequest() throws Exception {
+                // given
+                TilRequestDTO.UpdateTilRequest request = TilMockBuilder.createUpdateTilRequest(
+                        TilTestConstants.TEST_TIL_ID, "   "
+                );
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_400));
+            }
+
+            @Test
+            @DisplayName("tilId 0 이하 값 전달 시 HTTP 500 Internal Server Error")
+            @WithMockUser(username = "1")
+            void updateTil_InvalidTilId_InternalServerError() throws Exception {
+                // given
+                TilRequestDTO.UpdateTilRequest request = TilMockBuilder.createUpdateTilRequest(
+                        0L, TilTestConstants.UPDATED_TIL_TITLE
+                );
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isInternalServerError())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_500));
+            }
+
+            @Test
+            @DisplayName("title 40자 초과 시 HTTP 500 Internal Server Error")
+            @WithMockUser(username = "1")
+            void updateTil_TitleTooLong_InternalServerError() throws Exception {
+                // given
+                TilRequestDTO.UpdateTilRequest request = TilMockBuilder.createUpdateTilRequestWithLongTitle();
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isInternalServerError())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_500))
+                        .andExpect(jsonPath("$.success").value(false));
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 tilId 요청 시 HTTP 404 Not Found")
+            @WithMockUser(username = "1")
+            void updateTil_TilNotFound_NotFound() throws Exception {
+                // given
+                given(tilCommendService.getTilById(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID)))
+                        .willThrow(new RuntimeException(TilTestConstants.ERROR_TIL_NOT_FOUND));
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validUpdateRequest)))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_404))
+                        .andExpect(jsonPath("$.message").value(TilTestConstants.ERROR_TIL_NOT_FOUND));
+            }
+
+            @Test
+            @DisplayName("타인의 TIL 수정 시도 시 HTTP 403 Forbidden")
+            @WithMockUser(username = "1")
+            void updateTil_NotOwner_Forbidden() throws Exception {
+                // given
+                given(tilCommendService.getTilById(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID)))
+                        .willReturn(tilDetailResponse);
+                given(tilCommendService.updateTil(eq(TilTestConstants.TEST_TIL_ID), any(), eq(TilTestConstants.TEST_USER_ID)))
+                        .willThrow(new RuntimeException(TilTestConstants.ERROR_TIL_EDIT_DENIED));
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validUpdateRequest)))
+                        .andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_403))
+                        .andExpect(jsonPath("$.message").value(TilTestConstants.ERROR_TIL_EDIT_DENIED));
+
+                then(tilCommendService).should().updateTil(
+                        eq(TilTestConstants.TEST_TIL_ID),
+                        argThat(request -> request.getTitle().equals(TilTestConstants.UPDATED_TIL_TITLE)),
+                        eq(TilTestConstants.TEST_USER_ID)
+                );
+            }
+
+            @Test
+            @DisplayName("이미 삭제된 TIL 수정 시도 시 HTTP 410 Gone")
+            @WithMockUser(username = "1")
+            void updateTil_DeletedTil_Gone() throws Exception {
+                // given
+                given(tilCommendService.getTilById(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID)))
+                        .willThrow(new RuntimeException(TilTestConstants.ERROR_TIL_ALREADY_DELETED));
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validUpdateRequest)))
+                        .andExpect(status().isGone())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_410))
+                        .andExpect(jsonPath("$.message").value(TilTestConstants.ERROR_TIL_ALREADY_DELETED));
+            }
+
+            @Test
+            @DisplayName("서버 내부 오류 시 HTTP 500 Internal Server Error")
+            @WithMockUser(username = "1")
+            void updateTil_ServerError_InternalServerError() throws Exception {
+                // given
+                given(tilCommendService.getTilById(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID)))
+                        .willReturn(tilDetailResponse);
+                given(tilCommendService.updateTil(eq(TilTestConstants.TEST_TIL_ID), any(), eq(TilTestConstants.TEST_USER_ID)))
+                        .willThrow(new RuntimeException("예상치 못한 서버 오류"));
+
+                // when & then
+                mockMvc.perform(put("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(validUpdateRequest)))
+                        .andExpect(status().isInternalServerError())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_500))
+                        .andExpect(jsonPath("$.success").value(false));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("TIL 삭제")
+    class TilDeleteTest {
+
+        @Nested
+        @DisplayName("성공 시나리오")
+        class SuccessScenarios {
+
+            @Test
+            @DisplayName("유효한 tilId 배열로 요청 시 일괄 삭제")
+            @WithMockUser(username = "1")
+            void deleteTils_ValidRequest_Success() throws Exception {
+                // given
+                TilRequestDTO.BatchDeleteTilRequest request = TilMockBuilder.createBatchDeleteTilRequest();
+
+                willDoNothing().given(tilCommendService).deleteTil(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID));
+
+                // when & then
+                mockMvc.perform(delete("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_200))
+                        .andExpect(jsonPath("$.success").value(true));
+
+                then(tilCommendService).should().deleteTil(
+                        eq(TilTestConstants.TEST_TIL_ID),
+                        eq(TilTestConstants.TEST_USER_ID)
+                );
+            }
+
+            @Test
+            @DisplayName("deletedAt 시간 설정")
+            @WithMockUser(username = "1")
+            void deleteTils_DeletedAtSet() throws Exception {
+                // given
+                TilRequestDTO.BatchDeleteTilRequest request = TilMockBuilder.createBatchDeleteTilRequest();
+
+                willDoNothing().given(tilCommendService).deleteTil(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID));
+
+                // when & then
+                mockMvc.perform(delete("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk());
+
+                then(tilCommendService).should().deleteTil(
+                        eq(TilTestConstants.TEST_TIL_ID),
+                        eq(TilTestConstants.TEST_USER_ID)
+                );
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 시나리오")
+        class FailureScenarios {
+
+            @Test
+            @DisplayName("tilId null 전달 시 HTTP 400 Bad Request")
+            @WithMockUser(username = "1")
+            void deleteTils_NullTilIds_BadRequest() throws Exception {
+                // given
+                TilRequestDTO.BatchDeleteTilRequest request = TilMockBuilder.createBatchDeleteTilRequestWithNullIds();
+
+                // when & then
+                mockMvc.perform(delete("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_400))
+                        .andExpect(jsonPath("$.success").value(false));
+            }
+
+            @Test
+            @DisplayName("빈 배열 전달 시 HTTP 400 Bad Request")
+            @WithMockUser(username = "1")
+            void deleteTils_EmptyTilIds_BadRequest() throws Exception {
+                // given
+                TilRequestDTO.BatchDeleteTilRequest request = TilMockBuilder.createBatchDeleteTilRequestWithEmptyIds();
+
+                // when & then
+                mockMvc.perform(delete("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_400))
+                        .andExpect(jsonPath("$.success").value(false));
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 tilId 포함 시 '삭제하려는 TIL을 찾을 수 없습니다' 오류")
+            @WithMockUser(username = "1")
+            void deleteTils_NonExistentTilId_Error() throws Exception {
+                // given
+                TilRequestDTO.BatchDeleteTilRequest request = TilMockBuilder.createBatchDeleteTilRequestWithNonExistentId();
+
+                willThrow(new RuntimeException(TilTestConstants.ERROR_TIL_NOT_FOUND))
+                        .given(tilCommendService).deleteTil(eq(TilTestConstants.NON_EXISTENT_TIL_ID), eq(TilTestConstants.TEST_USER_ID));
+
+                // when & then
+                mockMvc.perform(delete("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isInternalServerError())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_500))
+                        .andExpect(jsonPath("$.message").value(TilTestConstants.ERROR_TIL_NOT_FOUND))
+                        .andExpect(jsonPath("$.success").value(false));
+            }
+
+            @Test
+            @DisplayName("타인의 TIL 삭제 시도 시 '해당 TIL의 소유자가 아닙니다' 오류")
+            @WithMockUser(username = "1")
+            void deleteTils_NotOwner_Error() throws Exception {
+                // given
+                TilRequestDTO.BatchDeleteTilRequest request = TilMockBuilder.createBatchDeleteTilRequest();
+
+                willThrow(new RuntimeException(TilTestConstants.ERROR_TIL_DELETE_DENIED))
+                        .given(tilCommendService).deleteTil(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID));
+
+                // when & then
+                mockMvc.perform(delete("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isInternalServerError())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_500))
+                        .andExpect(jsonPath("$.message").value(TilTestConstants.ERROR_TIL_DELETE_DENIED))
+                        .andExpect(jsonPath("$.success").value(false));
+            }
+
+            @Test
+            @DisplayName("이미 삭제된 TIL 포함 시 '이미 삭제된 TIL이 포함되어 있습니다' 오류")
+            @WithMockUser(username = "1")
+            void deleteTils_AlreadyDeletedTil_Error() throws Exception {
+                // given
+                TilRequestDTO.BatchDeleteTilRequest request = TilMockBuilder.createBatchDeleteTilRequest();
+
+                willThrow(new RuntimeException(TilTestConstants.ERROR_TIL_ALREADY_DELETED))
+                        .given(tilCommendService).deleteTil(eq(TilTestConstants.TEST_TIL_ID), eq(TilTestConstants.TEST_USER_ID));
+
+                // when & then
+                mockMvc.perform(delete("/api/v1/tils")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isInternalServerError())
+                        .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_500))
+                        .andExpect(jsonPath("$.message").value(TilTestConstants.ERROR_TIL_ALREADY_DELETED))
+                        .andExpect(jsonPath("$.success").value(false));
+            }
+        }
+    }
+}

--- a/src/test/java/com/youtil/Api/Tils/Service/TilUploadApiTest.java
+++ b/src/test/java/com/youtil/Api/Tils/Service/TilUploadApiTest.java
@@ -1,0 +1,391 @@
+package com.youtil.Api.Tils.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.youtil.Api.Tils.Controller.TilUploadController;
+import com.youtil.Api.Tils.Dto.TilUploadRequestDTO;
+import com.youtil.Api.Tils.Dto.TilUploadResponseDTO;
+import com.youtil.Constants.TilTestConstants;
+import com.youtil.Mock.TilMockBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest({TilUploadController.class})
+@DisplayName("TIL 깃허브 업로드 API 테스트")
+class TilUploadApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private TilUploadService tilUploadService;
+
+    // 각 테스트마다 새로운 객체로 초기화하여 테스트 데이터 격리 보장
+    private TilUploadRequestDTO.UploadRequest validUploadRequest;
+    private TilUploadResponseDTO.UploadToGitHubResponse successUploadResponse;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 데이터 격리: 각 테스트마다 새로운 Mock 객체 생성
+        validUploadRequest = TilMockBuilder.createTilUploadRequest();
+        successUploadResponse = TilMockBuilder.createSuccessUploadResponse();
+    }
+
+    @Nested
+    @DisplayName("성공 시나리오")
+    class SuccessScenarios {
+
+        @Test
+        @DisplayName("유효한 tilId로 요청 시 기본 설정된 레포지토리에 마크다운 파일로 업로드 성공")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_ValidRequest_Success() throws Exception {
+            // given
+            given(tilUploadService.uploadTilToGitHub(eq(validUploadRequest), eq(TilTestConstants.TEST_USER_ID)))
+                    .willReturn(successUploadResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.success").value(true))
+                    .andExpect(jsonPath("$.data.fileUrl").value(TilTestConstants.GITHUB_FILE_URL))
+                    // 검증 로직 강화: 업로드 응답 데이터 상세 검증
+                    .andExpect(jsonPath("$.data.commitSha").value(TilTestConstants.GITHUB_COMMIT_SHA))
+                    .andExpect(jsonPath("$.data.uploadedFilePath").value(TilTestConstants.GITHUB_FILE_PATH))
+                    .andExpect(jsonPath("$.data.message").value(TilTestConstants.SUCCESS_TIL_UPLOADED));
+
+            // 서비스 메서드 호출 검증
+            then(tilUploadService).should().uploadTilToGitHub(
+                    argThat(request -> request.getTilId().equals(TilTestConstants.TEST_TIL_ID)),
+                    eq(TilTestConstants.TEST_USER_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("업로드 후 isUploaded 상태 변경 확인")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_IsUploadedStatusChanged() throws Exception {
+            // given
+            given(tilUploadService.uploadTilToGitHub(eq(validUploadRequest), eq(TilTestConstants.TEST_USER_ID)))
+                    .willReturn(successUploadResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.success").value(true));
+
+            // 서비스 메서드 호출 검증: 정확한 파라미터로 호출되었는지 확인
+            then(tilUploadService).should().uploadTilToGitHub(
+                    argThat(request -> request.getTilId().equals(TilTestConstants.TEST_TIL_ID)),
+                    eq(TilTestConstants.TEST_USER_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("마크다운 형식으로 올바른 파일 경로 생성")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_CorrectMarkdownFilePath() throws Exception {
+            // given
+            given(tilUploadService.uploadTilToGitHub(eq(validUploadRequest), eq(TilTestConstants.TEST_USER_ID)))
+                    .willReturn(successUploadResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isOk())
+                    // 검증 로직 강화: 마크다운 파일 경로 검증
+                    .andExpect(jsonPath("$.data.uploadedFilePath").value(TilTestConstants.GITHUB_FILE_PATH))
+                    .andExpect(jsonPath("$.data.fileUrl").exists());
+
+            then(tilUploadService).should().uploadTilToGitHub(any(), eq(TilTestConstants.TEST_USER_ID));
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 시나리오")
+    class FailureScenarios {
+
+        @Test
+        @DisplayName("tilId null 전달 시 HTTP 400 Bad Request")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_NullTilId_BadRequest() throws Exception {
+            // given - 테스트 데이터 격리
+            TilUploadRequestDTO.UploadRequest request = TilMockBuilder.createTilUploadRequestWithNullTilId();
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_400))
+                    // 검증 로직 강화
+                    .andExpect(jsonPath("$.success").value(false));
+
+            // 서비스 메서드가 호출되지 않았는지 검증
+            then(tilUploadService).should(never()).uploadTilToGitHub(any(), any());
+        }
+
+        @Test
+        @DisplayName("tilId 음수 값 전달 시 HTTP 500 Internal Server Error")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_NegativeTilId_InternalServerError() throws Exception {
+            // given
+            TilUploadRequestDTO.UploadRequest request = TilMockBuilder.createTilUploadRequest(-1L);
+
+            // Mock 서비스가 null을 반환하도록 설정 (실제 동작과 맞춤)
+            given(tilUploadService.uploadTilToGitHub(any(TilUploadRequestDTO.UploadRequest.class), eq(TilTestConstants.TEST_USER_ID)))
+                    .willReturn(null);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_500))
+                    .andExpect(jsonPath("$.success").value(false));
+
+            then(tilUploadService).should().uploadTilToGitHub(any(), eq(TilTestConstants.TEST_USER_ID));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 tilId 요청 시 HTTP 404 Not Found")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_TilNotFound_NotFound() throws Exception {
+            // given
+            given(tilUploadService.uploadTilToGitHub(eq(validUploadRequest), eq(TilTestConstants.TEST_USER_ID)))
+                    .willThrow(new RuntimeException(TilTestConstants.ERROR_TIL_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_404))
+                    // 검증 로직 강화: 에러 메시지 검증
+                    .andExpect(jsonPath("$.message").value(TilTestConstants.ERROR_TIL_NOT_FOUND))
+                    .andExpect(jsonPath("$.success").value(false));
+
+            // 서비스 메서드 호출 검증: 정확한 파라미터로 호출되었는지 확인
+            then(tilUploadService).should().uploadTilToGitHub(
+                    argThat(request -> request.getTilId().equals(TilTestConstants.TEST_TIL_ID)),
+                    eq(TilTestConstants.TEST_USER_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("타인의 TIL 업로드 시도 시 HTTP 403 Forbidden")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_NotOwner_Forbidden() throws Exception {
+            // given
+            given(tilUploadService.uploadTilToGitHub(any(TilUploadRequestDTO.UploadRequest.class), eq(TilTestConstants.TEST_USER_ID)))
+                    .willThrow(new RuntimeException(TilTestConstants.ERROR_TIL_ACCESS_DENIED));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isInternalServerError()) // 실제 컨트롤러 응답에 맞춤
+                    .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_500))
+                    .andExpect(jsonPath("$.message").value("TIL 업로드 중 오류가 발생했습니다: " + TilTestConstants.ERROR_TIL_ACCESS_DENIED))
+                    .andExpect(jsonPath("$.success").value(false));
+
+            // 서비스 메서드 호출 검증
+            then(tilUploadService).should().uploadTilToGitHub(
+                    argThat(request -> request.getTilId().equals(TilTestConstants.TEST_TIL_ID)),
+                    eq(TilTestConstants.TEST_USER_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 TIL 업로드 시도 시 HTTP 500 Internal Server Error")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_DeletedTil_Gone() throws Exception {
+            // given
+            given(tilUploadService.uploadTilToGitHub(any(TilUploadRequestDTO.UploadRequest.class), eq(TilTestConstants.TEST_USER_ID)))
+                    .willThrow(new RuntimeException(TilTestConstants.ERROR_TIL_ALREADY_DELETED));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isInternalServerError()) // 410 → 500으로 변경
+                    .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_500)) // HTTP_410 → HTTP_500으로 변경
+                    .andExpect(jsonPath("$.message").value("TIL 업로드 중 오류가 발생했습니다: " + TilTestConstants.ERROR_TIL_ALREADY_DELETED)) // 에러 메시지 형식 맞춤
+                    .andExpect(jsonPath("$.success").value(false));
+
+            then(tilUploadService).should().uploadTilToGitHub(
+                    argThat(request -> request.getTilId().equals(TilTestConstants.TEST_TIL_ID)),
+                    eq(TilTestConstants.TEST_USER_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("기본 업로드 레포지토리 미설정 시 HTTP 400 Bad Request")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_RepositoryNotSet_BadRequest() throws Exception {
+            // given
+            given(tilUploadService.uploadTilToGitHub(eq(validUploadRequest), eq(TilTestConstants.TEST_USER_ID)))
+                    .willThrow(new RuntimeException(TilTestConstants.ERROR_REPOSITORY_NOT_SET));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_400))
+                    .andExpect(jsonPath("$.message").value(TilTestConstants.ERROR_REPOSITORY_NOT_SET))
+                    .andExpect(jsonPath("$.success").value(false));
+
+            // 서비스 메서드 호출 검증
+            then(tilUploadService).should().uploadTilToGitHub(
+                    argThat(request -> request.getTilId().equals(TilTestConstants.TEST_TIL_ID)),
+                    eq(TilTestConstants.TEST_USER_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("GitHub 토큰 미설정/만료 시 HTTP 401 Unauthorized")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_GithubTokenIssue_Unauthorized() throws Exception {
+            // given
+            String githubTokenError = "GitHub 토큰이 유효하지 않습니다.";
+            given(tilUploadService.uploadTilToGitHub(eq(validUploadRequest), eq(TilTestConstants.TEST_USER_ID)))
+                    .willThrow(new RuntimeException(githubTokenError));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_401))
+                    // 검증 로직 강화: GitHub 토큰 관련 에러 메시지 검증
+                    .andExpect(jsonPath("$.message").value(githubTokenError))
+                    .andExpect(jsonPath("$.success").value(false));
+
+            then(tilUploadService).should().uploadTilToGitHub(
+                    argThat(request -> request.getTilId().equals(TilTestConstants.TEST_TIL_ID)),
+                    eq(TilTestConstants.TEST_USER_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("GitHub 토큰 권한 부족 시 HTTP 401 Unauthorized")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_GithubTokenInsufficientPermission_Unauthorized() throws Exception {
+            // given
+            String permissionError = "GitHub 토큰의 권한이 부족합니다.";
+            given(tilUploadService.uploadTilToGitHub(eq(validUploadRequest), eq(TilTestConstants.TEST_USER_ID)))
+                    .willThrow(new RuntimeException(permissionError));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_401))
+                    .andExpect(jsonPath("$.message").value(permissionError));
+
+            then(tilUploadService).should().uploadTilToGitHub(any(), eq(TilTestConstants.TEST_USER_ID));
+        }
+
+        @Test
+        @DisplayName("설정된 레포지토리 삭제/접근 불가 시 HTTP 404 Not Found")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_RepositoryNotFound_NotFound() throws Exception {
+            // given
+            String repositoryError = "설정된 레포지토리를 찾을 수 없습니다.";
+            given(tilUploadService.uploadTilToGitHub(any(TilUploadRequestDTO.UploadRequest.class), eq(TilTestConstants.TEST_USER_ID)))
+                    .willThrow(new RuntimeException(repositoryError));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_404))
+                    .andExpect(jsonPath("$.message").value(repositoryError))
+                    .andExpect(jsonPath("$.success").value(false));
+
+            then(tilUploadService).should().uploadTilToGitHub(
+                    argThat(request -> request.getTilId().equals(TilTestConstants.TEST_TIL_ID)),
+                    eq(TilTestConstants.TEST_USER_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("GitHub API 호출 실패 시 HTTP 500 Internal Server Error")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_GithubApiFailure_InternalServerError() throws Exception {
+            // given
+            String apiError = "GitHub API 호출 중 오류가 발생했습니다.";
+            given(tilUploadService.uploadTilToGitHub(eq(validUploadRequest), eq(TilTestConstants.TEST_USER_ID)))
+                    .willThrow(new RuntimeException(apiError));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_500))
+                    .andExpect(jsonPath("$.message").value("TIL 업로드 중 오류가 발생했습니다: " + apiError))
+                    .andExpect(jsonPath("$.success").value(false));
+
+            then(tilUploadService).should().uploadTilToGitHub(any(), eq(TilTestConstants.TEST_USER_ID));
+        }
+
+        // 경계값 테스트 추가
+        @Test
+        @DisplayName("네트워크 타임아웃 시 HTTP 500 Internal Server Error")
+        @WithMockUser(username = "1")
+        void uploadTilToGitHub_NetworkTimeout_InternalServerError() throws Exception {
+            // given
+            String timeoutError = "GitHub 업로드 중 네트워크 타임아웃이 발생했습니다.";
+            given(tilUploadService.uploadTilToGitHub(eq(validUploadRequest), eq(TilTestConstants.TEST_USER_ID)))
+                    .willThrow(new RuntimeException(timeoutError));
+
+            // when & then
+            mockMvc.perform(post("/api/v1/tils/upload")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validUploadRequest)))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.code").value(TilTestConstants.HTTP_500))
+                    .andExpect(jsonPath("$.message").value("TIL 업로드 중 오류가 발생했습니다: " + timeoutError));
+
+            then(tilUploadService).should().uploadTilToGitHub(any(), eq(TilTestConstants.TEST_USER_ID));
+        }
+    }
+}

--- a/src/test/java/com/youtil/Constants/TilTestConstants.java
+++ b/src/test/java/com/youtil/Constants/TilTestConstants.java
@@ -1,0 +1,64 @@
+package com.youtil.Constants;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class TilTestConstants {
+
+    // 테스트 사용자 정보
+    public static final Long TEST_USER_ID = 1L;
+    public static final String TEST_USER_EMAIL = "test@example.com";
+    public static final String TEST_USER_NICKNAME = "testUser";
+    public static final String TEST_USER_PROFILE_IMAGE = "profile.jpg";
+    public static final String TEST_USER_DESCRIPTION = "테스트 사용자";
+
+    // 테스트 TIL 정보
+    public static final Long TEST_TIL_ID = 1L;
+    public static final Long NON_EXISTENT_TIL_ID = 999L;
+    public static final String TEST_TIL_TITLE = "Spring Boot 학습";
+    public static final String TEST_TIL_CONTENT = "오늘은 Spring Boot를 공부했다.";
+    public static final String TEST_TIL_CATEGORY = "BACKEND";
+    public static final List<String> TEST_TIL_TAGS = Arrays.asList("Spring", "Java", "Backend");
+    public static final String TEST_TIL_REPOSITORY = "test-repo";
+
+    // 수정 테스트 관련
+    public static final String UPDATED_TIL_TITLE = "수정된 Spring Boot 학습";
+    public static final String LONG_TITLE_41_CHARS = "이것은41자를초과하는매우긴제목입니다테스트용으로작성된긴제목";
+    public static final String VALID_TITLE_40_CHARS = "이것은정확히40자인제목입니다테스트용으로작성된제목이에용";
+
+    // GitHub 업로드 테스트 관련
+    public static final String GITHUB_TOKEN = "github_test_token";
+    public static final String GITHUB_REPOSITORY_CONFIG = "org:12345:main";
+    public static final String GITHUB_FILE_URL = "https://github.com/test/repo/blob/main/tils/2025-01-15.md";
+    public static final String GITHUB_COMMIT_SHA = "abc123def456";
+    public static final String GITHUB_FILE_PATH = "tils/2025-01-15.md";
+
+    // 카운트 관련
+    public static final int DEFAULT_RECOMMEND_COUNT = 0;
+    public static final int DEFAULT_VISITED_COUNT = 0;
+    public static final int DEFAULT_COMMENTS_COUNT = 0;
+
+    // 에러 메시지
+    public static final String ERROR_TIL_NOT_FOUND = "TIL을 찾을 수 없습니다.";
+    public static final String ERROR_TIL_ALREADY_DELETED = "이미 삭제된 TIL입니다.";
+    public static final String ERROR_TIL_ACCESS_DENIED = "본인의 TIL만 접근할 수 있습니다.";
+    public static final String ERROR_TIL_EDIT_DENIED = "TIL 수정 권한이 없습니다.";
+    public static final String ERROR_TIL_DELETE_DENIED = "TIL 삭제 권한이 없습니다.";
+    public static final String ERROR_REPOSITORY_NOT_SET = "기본 업로드 레포지토리가 설정되지 않았습니다. 먼저 레포지토리를 설정해주세요.";
+
+    // HTTP 상태 코드
+    public static final String HTTP_200 = "200";
+    public static final String HTTP_400 = "400";
+    public static final String HTTP_401 = "401";
+    public static final String HTTP_403 = "403";
+    public static final String HTTP_404 = "404";
+    public static final String HTTP_410 = "410";
+    public static final String HTTP_500 = "500";
+
+    // 성공 메시지
+    public static final String SUCCESS_TIL_UPDATED = "TIL 제목이 성공적으로 수정되었습니다.";
+    public static final String SUCCESS_TIL_UPLOADED = "TIL이 성공적으로 GitHub에 업로드되었습니다.";
+
+    private TilTestConstants() {
+    }
+}

--- a/src/test/java/com/youtil/Mock/TilMockBuilder.java
+++ b/src/test/java/com/youtil/Mock/TilMockBuilder.java
@@ -1,0 +1,207 @@
+package com.youtil.Mock;
+
+import com.youtil.Api.Tils.Dto.TilRequestDTO;
+import com.youtil.Api.Tils.Dto.TilResponseDTO;
+import com.youtil.Api.Tils.Dto.TilUploadRequestDTO;
+import com.youtil.Api.Tils.Dto.TilUploadResponseDTO;
+import com.youtil.Common.Enums.Status;
+import com.youtil.Constants.TilTestConstants;
+import com.youtil.Model.Til;
+import com.youtil.Model.User;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * TIL 테스트용 Mock 객체 생성 빌더
+ */
+public final class TilMockBuilder {
+
+    /**
+     * 테스트용 User ㄱ9엔티티 생성
+     */
+    public static User createTestUser() {
+        return createTestUser(TilTestConstants.TEST_USER_ID);
+    }
+
+    public static User createTestUser(Long userId) {
+        return User.builder()
+                .id(userId)
+                .email(TilTestConstants.TEST_USER_EMAIL)
+                .nickname(TilTestConstants.TEST_USER_NICKNAME)
+                .profileImageUrl(TilTestConstants.TEST_USER_PROFILE_IMAGE)
+                .description(TilTestConstants.TEST_USER_DESCRIPTION)
+                .githubToken(TilTestConstants.GITHUB_TOKEN)
+                .uploadRepository(TilTestConstants.GITHUB_REPOSITORY_CONFIG)
+                .status(Status.active)
+                .build();
+    }
+
+    /**
+     * 테스트용 Til 엔티티 생성
+     */
+    public static Til createTestTil() {
+        return createTestTil(createTestUser());
+    }
+
+    public static Til createTestTil(User user) {
+        return Til.builder()
+                .id(TilTestConstants.TEST_TIL_ID)
+                .user(user)
+                .title(TilTestConstants.TEST_TIL_TITLE)
+                .content(TilTestConstants.TEST_TIL_CONTENT)
+                .category(TilTestConstants.TEST_TIL_CATEGORY)
+                .tag(TilTestConstants.TEST_TIL_TAGS)
+                .isDisplay(true)
+                .commitRepository(TilTestConstants.TEST_TIL_REPOSITORY)
+                .isUploaded(false)
+                .recommendCount(TilTestConstants.DEFAULT_RECOMMEND_COUNT)
+                .visitedCount(TilTestConstants.DEFAULT_VISITED_COUNT)
+                .commentsCount(TilTestConstants.DEFAULT_COMMENTS_COUNT)
+                .status(Status.active)
+                .build();
+    }
+
+    /**
+     * TIL 수정 요청 DTO 생성
+     */
+    public static TilRequestDTO.UpdateTilRequest createUpdateTilRequest() {
+        return createUpdateTilRequest(TilTestConstants.TEST_TIL_ID, TilTestConstants.UPDATED_TIL_TITLE);
+    }
+
+    public static TilRequestDTO.UpdateTilRequest createUpdateTilRequest(Long tilId, String title) {
+        return TilRequestDTO.UpdateTilRequest.builder()
+                .tilId(tilId)
+                .title(title)
+                .build();
+    }
+
+    /**
+     * 40자 초과 제목으로 TIL 수정 요청 DTO 생성
+     */
+    public static TilRequestDTO.UpdateTilRequest createUpdateTilRequestWithLongTitle() {
+        return createUpdateTilRequest(TilTestConstants.TEST_TIL_ID, TilTestConstants.LONG_TITLE_41_CHARS);
+    }
+
+    /**
+     * 정확히 40자 제목으로 TIL 수정 요청 DTO 생성
+     */
+    public static TilRequestDTO.UpdateTilRequest createUpdateTilRequestWith40CharsTitle() {
+        return createUpdateTilRequest(TilTestConstants.TEST_TIL_ID, TilTestConstants.VALID_TITLE_40_CHARS);
+    }
+
+    /**
+     * null tilId로 TIL 수정 요청 DTO 생성
+     */
+    public static TilRequestDTO.UpdateTilRequest createUpdateTilRequestWithNullTilId() {
+        return createUpdateTilRequest(null, TilTestConstants.UPDATED_TIL_TITLE);
+    }
+
+    /**
+     * null title로 TIL 수정 요청 DTO 생성
+     */
+    public static TilRequestDTO.UpdateTilRequest createUpdateTilRequestWithNullTitle() {
+        return createUpdateTilRequest(TilTestConstants.TEST_TIL_ID, null);
+    }
+
+    /**
+     * TIL 일괄 삭제 요청 DTO 생성
+     */
+    public static TilRequestDTO.BatchDeleteTilRequest createBatchDeleteTilRequest() {
+        return TilRequestDTO.BatchDeleteTilRequest.builder()
+                .tilIds(Arrays.asList(TilTestConstants.TEST_TIL_ID))
+                .build();
+    }
+
+    /**
+     * null TIL ID 목록으로 일괄 삭제 요청 DTO 생성
+     */
+    public static TilRequestDTO.BatchDeleteTilRequest createBatchDeleteTilRequestWithNullIds() {
+        return TilRequestDTO.BatchDeleteTilRequest.builder()
+                .tilIds(null)
+                .build();
+    }
+
+    /**
+     * 빈 TIL ID 목록으로 일괄 삭제 요청 DTO 생성
+     */
+    public static TilRequestDTO.BatchDeleteTilRequest createBatchDeleteTilRequestWithEmptyIds() {
+        return TilRequestDTO.BatchDeleteTilRequest.builder()
+                .tilIds(Collections.emptyList())
+                .build();
+    }
+
+    /**
+     * 존재하지 않는 TIL ID로 일괄 삭제 요청 DTO 생성
+     */
+    public static TilRequestDTO.BatchDeleteTilRequest createBatchDeleteTilRequestWithNonExistentId() {
+        return TilRequestDTO.BatchDeleteTilRequest.builder()
+                .tilIds(Arrays.asList(TilTestConstants.NON_EXISTENT_TIL_ID))
+                .build();
+    }
+
+    /**
+     * TIL 업로드 요청 DTO 생성
+     */
+    public static TilUploadRequestDTO.UploadRequest createTilUploadRequest() {
+        return createTilUploadRequest(TilTestConstants.TEST_TIL_ID);
+    }
+
+    public static TilUploadRequestDTO.UploadRequest createTilUploadRequest(Long tilId) {
+        return TilUploadRequestDTO.UploadRequest.builder()
+                .tilId(tilId)
+                .build();
+    }
+
+    /**
+     * null tilId로 TIL 업로드 요청 DTO 생성
+     */
+    public static TilUploadRequestDTO.UploadRequest createTilUploadRequestWithNullTilId() {
+        return createTilUploadRequest(null);
+    }
+
+    /**
+     * TIL 업로드 성공 응답 DTO 생성
+     */
+    public static TilUploadResponseDTO.UploadToGitHubResponse createSuccessUploadResponse() {
+        return TilUploadResponseDTO.UploadToGitHubResponse.builder()
+                .success(true)
+                .fileUrl(TilTestConstants.GITHUB_FILE_URL)
+                .commitSha(TilTestConstants.GITHUB_COMMIT_SHA)
+                .uploadedFilePath(TilTestConstants.GITHUB_FILE_PATH)
+                .message(TilTestConstants.SUCCESS_TIL_UPLOADED)
+                .build();
+    }
+
+    /**
+     * TIL 상세 응답 DTO 생성
+     */
+    public static TilResponseDTO.TilDetailResponse createTilDetailResponse() {
+        return createTilDetailResponse(createTestTil());
+    }
+
+    public static TilResponseDTO.TilDetailResponse createTilDetailResponse(Til til) {
+        return TilResponseDTO.TilDetailResponse.builder()
+                .id(til.getId())
+                .userId(til.getUser().getId())
+                .nickname(til.getUser().getNickname())
+                .profileImageUrl(til.getUser().getProfileImageUrl())
+                .title(til.getTitle())
+                .content(til.getContent())
+                .category(til.getCategory())
+                .tag(til.getTag())
+                .isDisplay(til.getIsDisplay())
+                .commitRepository(til.getCommitRepository())
+                .isUploaded(til.getIsUploaded())
+                .recommendCount(til.getRecommendCount())
+                .visitedCount(til.getVisitedCount())
+                .commentsCount(til.getCommentsCount())
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+    }
+
+    private TilMockBuilder() {
+    }
+}


### PR DESCRIPTION
- 제목 : feat(268): TIL 도메인 (2차 3차 MVP기능)

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- TIL 수정
- TIL 삭제
- TIL 깃허브 업로드 


  <br/>

## 🔧 앞으로의 과제

- TIL 도메인의 1차 MVP 테스트 코드 작성

  <br/>

## ➕ 이슈 링크

#268 

<br/>
